### PR TITLE
[WIP] Convert from PyGTK and Gtk2 to PyGObject and Gtk3

### DIFF
--- a/docs/examples/demo.py
+++ b/docs/examples/demo.py
@@ -24,14 +24,14 @@ from __future__ import absolute_import
 import logging
 import random
 
-import pygtk
+import gi
 
-pygtk.require('2.0')
+gi.require_version('Gtk', '3.0')
 
-import gobject
-import gtk
-import gtk.gdk as gdk
-import pango
+from gi.repository import GObject
+from gi.repository import Gtk
+import Gtk.gdk as gdk
+from gi.repository import Pango
 
 try:
     import etk.docking
@@ -46,9 +46,9 @@ finally:
         DockGroup, DockItem, dockstore, settings
 
 
-class MainWindow(gtk.Window):
+class MainWindow(Gtk.Window):
     def __init__(self, docklayout=None, dockframe=None):
-        gtk.Window.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.set_default_size(500, 150)
         self.set_title('etk.docking demo')
@@ -56,7 +56,7 @@ class MainWindow(gtk.Window):
         self.file_counter = 1
         self.subwindows = []
 
-        vbox = gtk.VBox()
+        vbox = Gtk.VBox()
         vbox.set_spacing(4)
         self.add(vbox)
 
@@ -83,7 +83,7 @@ class MainWindow(gtk.Window):
         # To change default group behaviour:
         # self.docklayout.settings[None].inherit_settings = False
 
-        vbox.pack_start(self.dockframe)
+        vbox.pack_start(self.dockframe, True, True, 0)
 
         def on_item_closed(layout, group, item):
             item.destroy()
@@ -99,25 +99,25 @@ class MainWindow(gtk.Window):
         ########################################################################
         # Testing Tools
         ########################################################################
-        adddibutton = gtk.Button('Create docked items')
-        adddibutton.child.set_ellipsize(pango.ELLIPSIZE_MIDDLE)
+        adddibutton = Gtk.Button('Create docked items')
+        adddibutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         adddibutton.connect('clicked', self._on_add_di_button_clicked)
         vbox.pack_start(adddibutton, False, False)
 
-        orientationbutton = gtk.Button('Switch Orientation')
-        orientationbutton.child.set_ellipsize(pango.ELLIPSIZE_MIDDLE)
+        orientationbutton = Gtk.Button('Switch Orientation')
+        orientationbutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         orientationbutton.connect('clicked', self._on_orientation_button_clicked)
         vbox.pack_start(orientationbutton, False, False)
 
-        hbox = gtk.HBox()
+        hbox = Gtk.HBox()
 
-        savebutton = gtk.Button('Save layout')
-        savebutton.child.set_ellipsize(pango.ELLIPSIZE_MIDDLE)
+        savebutton = Gtk.Button('Save layout')
+        savebutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         savebutton.connect('clicked', self._on_save_button_clicked)
         hbox.pack_start(savebutton, True, True)
 
-        loadbutton = gtk.Button('Load layout')
-        loadbutton.child.set_ellipsize(pango.ELLIPSIZE_MIDDLE)
+        loadbutton = Gtk.Button('Load layout')
+        loadbutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         loadbutton.connect('clicked', self._on_load_button_clicked)
         hbox.pack_start(loadbutton, True, True)
 
@@ -145,10 +145,10 @@ class MainWindow(gtk.Window):
     def _on_orientation_button_clicked(self, button):
         def switch_orientation(paned):
             if isinstance(paned, DockPaned):
-                if paned.get_orientation() == gtk.ORIENTATION_HORIZONTAL:
-                    paned.set_orientation(gtk.ORIENTATION_VERTICAL)
+                if paned.get_orientation() == Gtk.Orientation.HORIZONTAL:
+                    paned.set_orientation(Gtk.Orientation.VERTICAL)
                 else:
-                    paned.set_orientation(gtk.ORIENTATION_HORIZONTAL)
+                    paned.set_orientation(Gtk.Orientation.HORIZONTAL)
 
                 for child in paned.get_children():
                     switch_orientation(child)
@@ -181,29 +181,29 @@ class MainWindow(gtk.Window):
 
     def _create_content(self, text=None):
         # Create a TextView and set some example text
-        scrolledwindow = gtk.ScrolledWindow()
-        scrolledwindow.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
-        textview = gtk.TextView()
+        scrolledwindow = Gtk.ScrolledWindow()
+        scrolledwindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        textview = Gtk.TextView()
         textview.get_buffer().set_text(text)
         scrolledwindow.add(textview)
         return scrolledwindow
 
     def _add_dockitems(self, dockgroup):
-        examples = [(gtk.STOCK_EXECUTE, 'calculator', '#!/usr/bin/env python\n\nprint \'Hello!\''),
-                    (gtk.STOCK_OPEN, 'Hi!', 'Hello!'),
-                    (gtk.STOCK_FILE, 'ABC', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
-                    (gtk.STOCK_FIND, 'abc', 'abcdefghijklmnopqrstuvwxyz'),
-                    (gtk.STOCK_HARDDISK, 'browser', '0123456789'),
-                    (gtk.STOCK_HOME, 'today', '9876543210'),
-                    gtk.Notebook]
+        examples = [(Gtk.STOCK_EXECUTE, 'calculator', '#!/usr/bin/env python\n\nprint \'Hello!\''),
+                    (Gtk.STOCK_OPEN, 'Hi!', 'Hello!'),
+                    (Gtk.STOCK_FILE, 'ABC', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+                    (Gtk.STOCK_FIND, 'abc', 'abcdefghijklmnopqrstuvwxyz'),
+                    (Gtk.STOCK_HARDDISK, 'browser', '0123456789'),
+                    (Gtk.STOCK_HOME, 'today', '9876543210'),
+                    Gtk.Notebook]
 
         for i in [1]:  # range(random.randrange(1, 10, 1)):
             example = random.choice(examples)
 
-            if example is gtk.Notebook:
-                child = gtk.Notebook()
-                child.append_page(gtk.Button('Click me'),
-                                  gtk.Label('New %s' % self.file_counter))
+            if example is Gtk.Notebook:
+                child = Gtk.Notebook()
+                child.append_page(Gtk.Button('Click me'),
+                                  Gtk.Label(label='New %s' % self.file_counter))
                 stock_id = ''
                 tooltip_text = 'notebook'
             else:
@@ -242,8 +242,8 @@ def main():
     #    handler.addFilter(logging.Filter('EtkDockPaned'))
 
     # Initialize mainloop
-    gobject.threads_init()
-    mainloop = gobject.MainLoop()
+    GObject.threads_init()
+    mainloop = GObject.MainLoop()
 
     # Initialize mainwindow
     mainwindow = MainWindow()

--- a/docs/examples/demo.py
+++ b/docs/examples/demo.py
@@ -34,15 +34,15 @@ import Gtk.gdk as gdk
 from gi.repository import Pango
 
 try:
-    import etk.docking
+    import etkdocking
 except ImportError:
     # The lib directory is most likely not on PYTHONPATH, so add it here.
     import os, sys
 
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'lib')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
     del os, sys
 finally:
-    from etk.docking import DockLayout, DockFrame, DockPaned, \
+    from etkdocking import DockLayout, DockFrame, DockPaned, \
         DockGroup, DockItem, dockstore, settings
 
 

--- a/docs/examples/demo.py
+++ b/docs/examples/demo.py
@@ -22,6 +22,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+
 import logging
 import random
 
@@ -29,21 +30,12 @@ import gi
 
 gi.require_version('Gtk', '3.0')
 
+from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk
-import Gtk.gdk as gdk
 from gi.repository import Pango
 
-try:
-    import etkdocking
-except ImportError:
-    # The lib directory is most likely not on PYTHONPATH, so add it here.
-    import os, sys
-
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-    del os, sys
-finally:
-    from etkdocking import DockLayout, DockFrame, DockPaned, \
+from etkdocking import DockLayout, DockFrame, DockPaned, \
         DockGroup, DockItem, dockstore, settings
 
 
@@ -84,7 +76,7 @@ class MainWindow(Gtk.Window):
         # To change default group behaviour:
         # self.docklayout.settings[None].inherit_settings = False
 
-        vbox.pack_start(self.dockframe, True, True, 0)
+        vbox.pack_start(child=self.dockframe, expand=True, fill=True, padding=0)
 
         def on_item_closed(layout, group, item):
             item.destroy()
@@ -100,29 +92,29 @@ class MainWindow(Gtk.Window):
         ########################################################################
         # Testing Tools
         ########################################################################
-        adddibutton = Gtk.Button('Create docked items')
+        adddibutton = Gtk.Button.new_with_label('Create docked items')
         adddibutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         adddibutton.connect('clicked', self._on_add_di_button_clicked)
-        vbox.pack_start(adddibutton, False, False)
+        vbox.pack_start(child=adddibutton, expand=False, fill=False, padding=0)
 
-        orientationbutton = Gtk.Button('Switch Orientation')
+        orientationbutton = Gtk.Button.new_with_label('Switch Orientation')
         orientationbutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         orientationbutton.connect('clicked', self._on_orientation_button_clicked)
-        vbox.pack_start(orientationbutton, False, False)
+        vbox.pack_start(child=orientationbutton, expand=False, fill=False, padding=0)
 
         hbox = Gtk.HBox()
 
-        savebutton = Gtk.Button('Save layout')
+        savebutton = Gtk.Button.new_with_label('Save layout')
         savebutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         savebutton.connect('clicked', self._on_save_button_clicked)
-        hbox.pack_start(savebutton, True, True)
+        hbox.pack_start(child=savebutton, expand=True, fill=True, padding=0)
 
-        loadbutton = Gtk.Button('Load layout')
+        loadbutton = Gtk.Button.new_with_label('Load layout')
         loadbutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         loadbutton.connect('clicked', self._on_load_button_clicked)
-        hbox.pack_start(loadbutton, True, True)
+        hbox.pack_start(child=loadbutton, expand=True, fill=True, padding=0)
 
-        vbox.pack_start(hbox, False, False)
+        vbox.pack_start(child=hbox, expand=False, fill=False, padding=0)
 
         self.show_all()
 
@@ -243,8 +235,7 @@ def main():
     #    handler.addFilter(logging.Filter('EtkDockPaned'))
 
     # Initialize mainloop
-    GObject.threads_init()
-    mainloop = GObject.MainLoop()
+    mainloop = GLib.MainLoop()
 
     # Initialize mainwindow
     mainwindow = MainWindow()

--- a/docs/examples/demo.py
+++ b/docs/examples/demo.py
@@ -21,6 +21,7 @@
 
 
 from __future__ import absolute_import
+from __future__ import print_function
 import logging
 import random
 
@@ -87,12 +88,12 @@ class MainWindow(Gtk.Window):
 
         def on_item_closed(layout, group, item):
             item.destroy()
-            print 'closed item:', item.title
+            print('closed item:', item.title)
 
         self.docklayout.connect('item-closed', on_item_closed)
 
         def on_item_selected(layout, group, item):
-            print 'Selected item:', item.title
+            print('Selected item:', item.title)
 
         self.docklayout.connect('item-selected', on_item_selected)
 
@@ -215,7 +216,7 @@ class MainWindow(Gtk.Window):
             di = DockItem(title='New %s' % self.file_counter, title_tooltip_text=tooltip_text, stock_id=stock_id)
 
             def on_close(item):
-                print 'close:', item
+                print('close:', item)
 
             di.connect('close', on_close)
             di.add(child)

--- a/docs/examples/demo.py
+++ b/docs/examples/demo.py
@@ -143,10 +143,11 @@ class MainWindow(Gtk.Window):
                 else:
                     paned.set_orientation(Gtk.Orientation.HORIZONTAL)
 
-                for child in paned.get_children():
+                child = paned.get_child()
+                if child:
                     switch_orientation(child)
 
-        paned = self.dockframe.get_children()[0]
+        paned = self.dockframe.get_child()
         switch_orientation(paned)
 
     def _on_save_button_clicked(self, button):

--- a/docs/examples/dockgroupdemo.py
+++ b/docs/examples/dockgroupdemo.py
@@ -25,10 +25,10 @@ from __future__ import absolute_import
 import logging
 import random
 
-import gobject
-import gtk
-import gtk.gdk as gdk
-import pango
+from gi.repository import GObject
+from gi.repository import Gtk
+import Gtk.gdk as gdk
+from gi.repository import Pango
 
 try:
     from etk.docking import DockLayout, DockPaned, DockGroup, DockItem
@@ -42,16 +42,16 @@ except ImportError:
     del os, sys
 
 
-class MainWindow(gtk.Window):
+class MainWindow(Gtk.Window):
     def __init__(self):
-        gtk.Window.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.set_default_size(500, 150)
         self.set_title('DockGroup Demo')
         self.set_border_width(4)
         self.file_counter = 1
 
-        vbox = gtk.VBox()
+        vbox = Gtk.VBox()
         vbox.set_spacing(4)
         self.add(vbox)
 
@@ -59,13 +59,13 @@ class MainWindow(gtk.Window):
         # Docking
         ########################################################################
         self.dg = DockGroup()
-        vbox.pack_start(self.dg)
+        vbox.pack_start(self.dg, True, True, 0)
 
         ########################################################################
         # Testing Tools
         ########################################################################
-        adddibutton = gtk.Button('Create docked items')
-        adddibutton.child.set_ellipsize(pango.ELLIPSIZE_MIDDLE)
+        adddibutton = Gtk.Button('Create docked items')
+        adddibutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         adddibutton.connect('clicked', self._on_add_di_button_clicked)
         vbox.pack_start(adddibutton, False, False)
 
@@ -83,9 +83,9 @@ class MainWindow(gtk.Window):
             icon_name, tooltip_text, text = random.choice(examples)
 
             # Create a TextView and set some example text
-            scrolledwindow = gtk.ScrolledWindow()
-            scrolledwindow.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
-            textview = gtk.TextView()
+            scrolledwindow = Gtk.ScrolledWindow()
+            scrolledwindow.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+            textview = Gtk.TextView()
             textview.get_buffer().set_text(text)
             scrolledwindow.add(textview)
 
@@ -115,8 +115,8 @@ def main():
     #    handler.addFilter(logging.Filter('EtkDockGroup'))
 
     # Initialize mainloop
-    gobject.threads_init()
-    mainloop = gobject.MainLoop()
+    GObject.threads_init()
+    mainloop = GObject.MainLoop()
 
     # Initialize mainwindow
     mainwindow = MainWindow()

--- a/docs/examples/dockgroupdemo.py
+++ b/docs/examples/dockgroupdemo.py
@@ -22,6 +22,7 @@
 
 from __future__ import absolute_import
 
+from builtins import range
 import logging
 import random
 

--- a/docs/examples/dockgroupdemo.py
+++ b/docs/examples/dockgroupdemo.py
@@ -60,15 +60,15 @@ class MainWindow(Gtk.Window):
         # Docking
         ########################################################################
         self.dg = DockGroup()
-        vbox.pack_start(self.dg, True, True, 0)
+        vbox.pack_start(child=self.dg, expand=True, fill=True, padding=0)
 
         ########################################################################
         # Testing Tools
         ########################################################################
-        adddibutton = Gtk.Button('Create docked items')
+        adddibutton = Gtk.Button.new_with_label('Create docked items')
         adddibutton.get_child().set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         adddibutton.connect('clicked', self._on_add_di_button_clicked)
-        vbox.pack_start(adddibutton, False, False)
+        vbox.pack_start(child=adddibutton, expand=False, fill=False, padding=0)
 
         self.show_all()
 

--- a/docs/examples/dockgroupdemo.py
+++ b/docs/examples/dockgroupdemo.py
@@ -31,13 +31,13 @@ import Gtk.gdk as gdk
 from gi.repository import Pango
 
 try:
-    from etk.docking import DockLayout, DockPaned, DockGroup, DockItem
+    from etkdocking import DockLayout, DockPaned, DockGroup, DockItem
 except ImportError:
     # The lib directory is most likely not on PYTHONPATH, so add it here.
     import os, sys
 
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'lib')))
-    from etk.docking import DockLayout, DockPaned, DockGroup, DockItem
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+    from etkdocking import DockLayout, DockPaned, DockGroup, DockItem
 
     del os, sys
 

--- a/docs/features/steps.py
+++ b/docs/features/steps.py
@@ -11,7 +11,7 @@ from etk.docking.docklayout import drag_motion, drag_end, drag_failed
 
 class StubContext(object):
     def __init__(self, source_widget, items):
-        self.targets = [DRAG_TARGET_ITEM_LIST[0]]
+        self.targets = [DRAG_TARGET_ITEM_LIST.target]
         self.source_widget = source_widget
         # Set up dragcontext (nornally done in motion_notify event)
 

--- a/docs/features/steps.py
+++ b/docs/features/steps.py
@@ -35,7 +35,7 @@ def tear_down(_):
 
 @Given('a window with (\d+) dockgroups?')
 def default_window(n_groups):
-    world.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+    world.window = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
     world.window.set_default_size(800, 150)
     world.frame = DockFrame()
     world.window.add(world.frame)

--- a/docs/features/steps.py
+++ b/docs/features/steps.py
@@ -1,3 +1,9 @@
+from __future__ import print_function
+from __future__ import division
+from builtins import next
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import gi
 
 gi.require_version('Gtk', '3.0')
@@ -147,7 +153,7 @@ def drop_item_on_content(name):
 
     a = dest_group.allocation
 
-    x, y = a.x + a.width / 2, a.y + a.height / 2
+    x, y = a.x + old_div(a.width, 2), a.y + old_div(a.height, 2)
     drop_item(dest_group, x, y)
 
 
@@ -178,7 +184,7 @@ def drop_between_groups(group1name, group2name):
     assert index == [i.get_child() for i in paned._items].index(group2) - 1
     handle = paned._handles[index]
 
-    x, y = handle.area.x + handle.area.width / 2, handle.area.y + handle.area.height / 2
+    x, y = handle.area.x + old_div(handle.area.width, 2), handle.area.y + old_div(handle.area.height, 2)
     drop_item(paned, x, y)
 
 
@@ -186,7 +192,7 @@ def drop_between_groups(group1name, group2name):
 def drop_before_first_group():
     first_group = world.groups[0]
     a = first_group.allocation
-    x, y = a.x, a.y + a.height / 2
+    x, y = a.x, a.y + old_div(a.height, 2)
     drop_item(first_group, x, y)
 
 
@@ -194,7 +200,7 @@ def drop_before_first_group():
 def drop_it_outside_of_the_frame():
     source_widget, items = world.dragged_items
     drag_failed(source_widget, StubContext(source_widget, items), 1)
-    world.new_frame = world.layout.get_floating_frames().next()
+    world.new_frame = next(world.layout.get_floating_frames())
 
 
 @Then('item "([^"]+)" is part of "([^"]+)"')
@@ -224,8 +230,8 @@ def placed_before_tab(name):
     start_a_main_loop()
     assert len(world.dropped_items) == 1
     items = newgroup.visible_items
-    print 'it has been placed in just before', items.index(world.dropped_items[0]),
-    print items.index(item)
+    print('it has been placed in just before', items.index(world.dropped_items[0]), end=' ')
+    print(items.index(item))
     assert items
     assert items.index(world.dropped_items[0]) == items.index(item) - 1
 

--- a/docs/features/steps.py
+++ b/docs/features/steps.py
@@ -1,9 +1,9 @@
-import pygtk
+import gi
 
-pygtk.require('2.0')
+gi.require_version('Gtk', '3.0')
 
 from freshen import Before, After, AfterStep, Given, When, Then, scc as world
-import gtk
+from gi.repository import Gtk
 from etk.docking import DockPaned, DockGroup, DockLayout, DockFrame, DockItem
 from etk.docking.dnd import DRAG_TARGET_ITEM_LIST, DockDragContext
 from etk.docking.docklayout import drag_motion, drag_end, drag_failed
@@ -35,7 +35,7 @@ def tear_down(_):
 
 @Given('a window with (\d+) dockgroups?')
 def default_window(n_groups):
-    world.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
+    world.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
     world.window.set_default_size(800, 150)
     world.frame = DockFrame()
     world.window.add(world.frame)
@@ -61,7 +61,7 @@ def setup_items(one_other, n_items):
     else:
         index = world.item_index + 1
     for n in range(int(n_items)):
-        button = gtk.Button()
+        button = Gtk.Button()
         item = DockItem(icon_name='file', title='Item %s' % n, title_tooltip_text='')
         item.add(button)
         item.show()
@@ -72,9 +72,9 @@ def setup_items(one_other, n_items):
 @Given('start a main loop')
 def start_a_main_loop():
     world.window.show_all()
-    # simulate gtk.main()
-    while gtk.events_pending():
-        gtk.main_iteration()
+    # simulate Gtk.main()
+    while Gtk.events_pending():
+        Gtk.main_iteration()
 
 
 @Given('define dockgroup (\d+) as "([^"]+)"')
@@ -174,8 +174,8 @@ def drop_between_groups(group1name, group2name):
     # Test is restricted to two groups having the same DockPaned as parent
     assert paned is group2.get_parent()
 
-    index = [i.child for i in paned._items].index(group1)
-    assert index == [i.child for i in paned._items].index(group2) - 1
+    index = [i.get_child() for i in paned._items].index(group1)
+    assert index == [i.get_child() for i in paned._items].index(group2) - 1
     handle = paned._handles[index]
 
     x, y = handle.area.x + handle.area.width / 2, handle.area.y + handle.area.height / 2

--- a/docs/platform/colors.py
+++ b/docs/platform/colors.py
@@ -27,15 +27,15 @@ to stdout.
 
 from __future__ import absolute_import
 
-import pygtk
+import gi
 
-pygtk.require('2.0')
+gi.require_version('Gtk', '3.0')
 
-import gtk
+from gi.repository import Gtk
 
 
 def main():
-    w = gtk.Window()
+    w = Gtk.Window()
     w.show()
 
     colors1 = ['fg', 'bg', 'base', 'light', 'mid', 'dark', 'text', 'text_aa']
@@ -55,19 +55,19 @@ def main():
         print '      <tr>'
         print '        <td><b>%s</b></td>' % attribute
 
-        color = w.style.__getattribute__(attribute)[gtk.STATE_INSENSITIVE]
+        color = w.style.__getattribute__(attribute)[Gtk.StateType.INSENSITIVE]
         print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
         int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
-        color = w.style.__getattribute__(attribute)[gtk.STATE_NORMAL]
+        color = w.style.__getattribute__(attribute)[Gtk.StateType.NORMAL]
         print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
         int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
-        color = w.style.__getattribute__(attribute)[gtk.STATE_PRELIGHT]
+        color = w.style.__getattribute__(attribute)[Gtk.StateType.PRELIGHT]
         print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
         int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
-        color = w.style.__getattribute__(attribute)[gtk.STATE_ACTIVE]
+        color = w.style.__getattribute__(attribute)[Gtk.StateType.ACTIVE]
         print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
         int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
-        color = w.style.__getattribute__(attribute)[gtk.STATE_SELECTED]
+        color = w.style.__getattribute__(attribute)[Gtk.StateType.SELECTED]
         print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
         int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
 

--- a/docs/platform/colors.py
+++ b/docs/platform/colors.py
@@ -26,7 +26,10 @@ to stdout.
 '''
 
 from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
 
+from past.utils import old_div
 import gi
 
 gi.require_version('Gtk', '3.0')
@@ -41,47 +44,47 @@ def main():
     colors1 = ['fg', 'bg', 'base', 'light', 'mid', 'dark', 'text', 'text_aa']
     colors2 = ['white', 'black']
 
-    print '    <table border=0>'
-    print '      <tr>'
-    print '        <td>&nbsp;</td>'
-    print '        <td><b>STATE_INSENSITIVE</b></td>'
-    print '        <td><b>STATE_NORMAL</b></td>'
-    print '        <td><b>STATE_PRELIGHT</b></td>'
-    print '        <td><b>STATE_ACTIVE</b></td>'
-    print '        <td><b>STATE_SELECTED</b></td>'
-    print '      </tr>'
+    print('    <table border=0>')
+    print('      <tr>')
+    print('        <td>&nbsp;</td>')
+    print('        <td><b>STATE_INSENSITIVE</b></td>')
+    print('        <td><b>STATE_NORMAL</b></td>')
+    print('        <td><b>STATE_PRELIGHT</b></td>')
+    print('        <td><b>STATE_ACTIVE</b></td>')
+    print('        <td><b>STATE_SELECTED</b></td>')
+    print('      </tr>')
 
     for attribute in colors1:
-        print '      <tr>'
-        print '        <td><b>%s</b></td>' % attribute
+        print('      <tr>')
+        print('        <td><b>%s</b></td>' % attribute)
 
         color = w.style.__getattribute__(attribute)[Gtk.StateType.INSENSITIVE]
-        print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
-        int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
+        print('        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
+        int(old_div(color.red, 256.00)), int(old_div(color.green, 256.00)), int(old_div(color.blue, 256.00))))
         color = w.style.__getattribute__(attribute)[Gtk.StateType.NORMAL]
-        print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
-        int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
+        print('        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
+        int(old_div(color.red, 256.00)), int(old_div(color.green, 256.00)), int(old_div(color.blue, 256.00))))
         color = w.style.__getattribute__(attribute)[Gtk.StateType.PRELIGHT]
-        print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
-        int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
+        print('        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
+        int(old_div(color.red, 256.00)), int(old_div(color.green, 256.00)), int(old_div(color.blue, 256.00))))
         color = w.style.__getattribute__(attribute)[Gtk.StateType.ACTIVE]
-        print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
-        int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
+        print('        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
+        int(old_div(color.red, 256.00)), int(old_div(color.green, 256.00)), int(old_div(color.blue, 256.00))))
         color = w.style.__getattribute__(attribute)[Gtk.StateType.SELECTED]
-        print '        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
-        int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
+        print('        <td bgcolor="#%x%x%x">&nbsp;</td>' % (
+        int(old_div(color.red, 256.00)), int(old_div(color.green, 256.00)), int(old_div(color.blue, 256.00))))
 
-        print '      </tr>'
+        print('      </tr>')
 
     for attribute in colors2:
-        print '      <tr>'
-        print '        <td><b>%s</b></td>' % attribute
+        print('      <tr>')
+        print('        <td><b>%s</b></td>' % attribute)
         color = w.style.__getattribute__(attribute)
-        print '        <td colspan="5" bgcolor="#%x%x%x">&nbsp;</td>' % (
-        int(color.red / 256.00), int(color.green / 256.00), int(color.blue / 256.00))
-        print '      </tr>'
+        print('        <td colspan="5" bgcolor="#%x%x%x">&nbsp;</td>' % (
+        int(old_div(color.red, 256.00)), int(old_div(color.green, 256.00)), int(old_div(color.blue, 256.00))))
+        print('      </tr>')
 
-    print '    </table>'
+    print('    </table>')
 
 
 if __name__ == '__main__':

--- a/docs/reference/source/api/dockgroup.rst
+++ b/docs/reference/source/api/dockgroup.rst
@@ -4,5 +4,5 @@
 .. autoclass:: etk.docking.DockGroup
     :show-inheritance:
     :members: append_item, prepend_item, insert_item, remove_item, item_num,
-              get_n_items, get_nth_item, get_current_item, set_current_item,
+              get_num_items, get_nth_item, get_current_item, set_current_item,
               next_item, prev_item, reorder_item

--- a/etkdocking/__init__.py
+++ b/etkdocking/__init__.py
@@ -29,27 +29,27 @@ __docformat__ = 'restructuredtext'
 # Initialization
 ############################################################################
 try:
-    import pygtk
+    import gi
 except ImportError:
     pass
 else:
-    pygtk.require('2.0')
+    gi.require_version('Gtk', '3.0')
 import os, gtk
 
 # Register some custom icons into the default icon theme
 path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'icons', '16x16'))
-gtk.icon_theme_add_builtin_icon('compact-close', 16,
-                                gtk.gdk.pixbuf_new_from_file(os.path.join(path, 'compact-close.png')))
-gtk.icon_theme_add_builtin_icon('compact-close-prelight', 16,
-                                gtk.gdk.pixbuf_new_from_file(os.path.join(path, 'compact-close-prelight.png')))
-gtk.icon_theme_add_builtin_icon('compact-list', 16,
-                                gtk.gdk.pixbuf_new_from_file(os.path.join(path, 'compact-list.png')))
-gtk.icon_theme_add_builtin_icon('compact-minimize', 16,
-                                gtk.gdk.pixbuf_new_from_file(os.path.join(path, 'compact-minimize.png')))
-gtk.icon_theme_add_builtin_icon('compact-maximize', 16,
-                                gtk.gdk.pixbuf_new_from_file(os.path.join(path, 'compact-maximize.png')))
-gtk.icon_theme_add_builtin_icon('compact-restore', 16,
-                                gtk.gdk.pixbuf_new_from_file(os.path.join(path, 'compact-restore.png')))
+Gtk.icon_theme_add_builtin_icon('compact-close', 16,
+                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-close.png')))
+Gtk.icon_theme_add_builtin_icon('compact-close-prelight', 16,
+                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-close-prelight.png')))
+Gtk.icon_theme_add_builtin_icon('compact-list', 16,
+                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-list.png')))
+Gtk.icon_theme_add_builtin_icon('compact-minimize', 16,
+                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-minimize.png')))
+Gtk.icon_theme_add_builtin_icon('compact-maximize', 16,
+                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-maximize.png')))
+Gtk.icon_theme_add_builtin_icon('compact-restore', 16,
+                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-restore.png')))
 
 # Check for elib, not required.
 try:
@@ -68,7 +68,7 @@ del os, gtk, path
 
 ############################################################################
 # GtkBuilder and Glade create GObject instances (and thus GTK+ widgets) using
-# gobject.new(). For this to work, we have to be sure our subclasses have been
+# GObject.new(). For this to work, we have to be sure our subclasses have been
 # registered with the GObject type system when etk.docking is imported.
 # This also defines the widgets that can be considered public.
 ############################################################################

--- a/etkdocking/__init__.py
+++ b/etkdocking/__init__.py
@@ -28,13 +28,11 @@ __docformat__ = 'restructuredtext'
 ############################################################################
 # Initialization
 ############################################################################
-try:
-    import gi
-except ImportError:
-    pass
-else:
-    gi.require_version('Gtk', '3.0')
-import os, gtk
+import os
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GdkPixbuf
 
 # Register some custom icons into the default icon theme
 path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'icons', '16x16'))

--- a/etkdocking/__init__.py
+++ b/etkdocking/__init__.py
@@ -32,40 +32,12 @@ import os
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GdkPixbuf
+from gi.repository import Gtk
 
 # Register some custom icons into the default icon theme
+icon_theme = Gtk.IconTheme.get_default()
 path = os.path.abspath(os.path.join(os.path.dirname(__file__), "icons", "16x16"))
-Gtk.IconTheme.add_builtin_icon(
-    "compact-close",
-    16,
-    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-close.png")),
-)
-Gtk.IconTheme.add_builtin_icon(
-    "compact-close-prelight",
-    16,
-    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-close-prelight.png")),
-)
-Gtk.IconTheme.add_builtin_icon(
-    "compact-list",
-    16,
-    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-list.png")),
-)
-Gtk.IconTheme.add_builtin_icon(
-    "compact-minimize",
-    16,
-    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-minimize.png")),
-)
-Gtk.IconTheme.add_builtin_icon(
-    "compact-maximize",
-    16,
-    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-maximize.png")),
-)
-Gtk.IconTheme.add_builtin_icon(
-    "compact-restore",
-    16,
-    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-restore.png")),
-)
+icon_theme.add_resource_path(path)
 
 # Check for elib, not required.
 try:

--- a/etkdocking/__init__.py
+++ b/etkdocking/__init__.py
@@ -62,7 +62,7 @@ else:
     del localedir, install_module
 
 # Keep our namespace nice and tidy
-del os, gtk, path
+del os, gi, path
 
 ############################################################################
 # GtkBuilder and Glade create GObject instances (and thus GTK+ widgets) using
@@ -71,8 +71,8 @@ del os, gtk, path
 # This also defines the widgets that can be considered public.
 ############################################################################
 from .docklayout import DockLayout
-from etkdocking.dockframe import DockFrame
+from .dockframe import DockFrame
 from .dockpaned import DockPaned
-from etkdocking.dockgroup import DockGroup
+from .dockgroup import DockGroup
 from .dockitem import DockItem
 from .docksettings import settings

--- a/etkdocking/__init__.py
+++ b/etkdocking/__init__.py
@@ -35,19 +35,37 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GdkPixbuf
 
 # Register some custom icons into the default icon theme
-path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'icons', '16x16'))
-Gtk.icon_theme_add_builtin_icon('compact-close', 16,
-                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-close.png')))
-Gtk.icon_theme_add_builtin_icon('compact-close-prelight', 16,
-                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-close-prelight.png')))
-Gtk.icon_theme_add_builtin_icon('compact-list', 16,
-                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-list.png')))
-Gtk.icon_theme_add_builtin_icon('compact-minimize', 16,
-                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-minimize.png')))
-Gtk.icon_theme_add_builtin_icon('compact-maximize', 16,
-                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-maximize.png')))
-Gtk.icon_theme_add_builtin_icon('compact-restore', 16,
-                                GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, 'compact-restore.png')))
+path = os.path.abspath(os.path.join(os.path.dirname(__file__), "icons", "16x16"))
+Gtk.IconTheme.add_builtin_icon(
+    "compact-close",
+    16,
+    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-close.png")),
+)
+Gtk.IconTheme.add_builtin_icon(
+    "compact-close-prelight",
+    16,
+    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-close-prelight.png")),
+)
+Gtk.IconTheme.add_builtin_icon(
+    "compact-list",
+    16,
+    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-list.png")),
+)
+Gtk.IconTheme.add_builtin_icon(
+    "compact-minimize",
+    16,
+    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-minimize.png")),
+)
+Gtk.IconTheme.add_builtin_icon(
+    "compact-maximize",
+    16,
+    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-maximize.png")),
+)
+Gtk.IconTheme.add_builtin_icon(
+    "compact-restore",
+    16,
+    GdkPixbuf.Pixbuf.new_from_file(os.path.join(path, "compact-restore.png")),
+)
 
 # Check for elib, not required.
 try:

--- a/etkdocking/compactbutton.py
+++ b/etkdocking/compactbutton.py
@@ -26,7 +26,10 @@ from logging import getLogger
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk, GObject
+from gi.repository import Gtk
+from gi.repository import Gdk
+from gi.repository import GObject
+from gi.repository import GLib
 
 from .util import load_icon
 
@@ -42,33 +45,33 @@ class CompactButton(Gtk.Widget):
                             'icon name normal',
                             'icon name normal',
                             '',
-                            GObject.PARAM_READWRITE),
+                            GObject.ParamFlags.READWRITE),
                        'icon-name-prelight':
                            (GObject.TYPE_STRING,
                             'icon name prelight',
                             'icon name prelight',
                             '',
-                            GObject.PARAM_READWRITE),
+                            GObject.ParamFlags.READWRITE),
                        'icon-name-active':
                            (GObject.TYPE_STRING,
                             'icon name active',
                             'icon name active',
                             '',
-                            GObject.PARAM_READWRITE),
+                            GObject.ParamFlags.READWRITE),
                        'size':
                            (GObject.TYPE_UINT,
                             'size',
                             'size',
                             0,
-                            GObject.G_MAXUINT,
+                            GLib.MAXUINT,
                             16,
-                            GObject.PARAM_READWRITE),
+                            GObject.ParamFlags.READWRITE),
                        'has-frame':
                            (GObject.TYPE_BOOLEAN,
                             'has frame',
                             'has frame',
                             True,
-                            GObject.PARAM_READWRITE)}
+                            GObject.ParamFlags.READWRITE)}
 
     def __init__(self, icon_name_normal='', size=16, has_frame=True):
         GObject.GObject.__init__(self)

--- a/etkdocking/compactbutton.py
+++ b/etkdocking/compactbutton.py
@@ -72,7 +72,8 @@ class CompactButton(Gtk.Widget):
 
     def __init__(self, icon_name_normal='', size=16, has_frame=True):
         GObject.GObject.__init__(self)
-        self.set_flags(self.flags() | Gtk.NO_WINDOW)
+        # TODO this is PyGTK specific, and no equivalent in PyGi. Does it need to be GInitiallyUnowned?
+        # self.set_flags(self.flags() | Gtk.NO_WINDOW)
 
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))

--- a/etkdocking/compactbutton.py
+++ b/etkdocking/compactbutton.py
@@ -222,7 +222,7 @@ class CompactButton(Gtk.Widget):
         self.allocation = allocation
 
         if self.get_realized():
-            self._input_window.move_resize(*self.allocation)
+            self._input_window.move_resize(allocation.x, allocation.y, allocation.width, allocation.height)
 
     def do_draw(self, cr):
         # Draw icon

--- a/etkdocking/compactbutton.py
+++ b/etkdocking/compactbutton.py
@@ -23,55 +23,55 @@ from __future__ import absolute_import
 from builtins import hex
 from logging import getLogger
 
-import gobject
-import gtk
-import gtk.gdk as gdk
+from gi.repository import GObject
+from gi.repository import Gtk
+import Gtk.gdk as gdk
 
 from .util import load_icon
 
 
-class CompactButton(gtk.Widget):
+class CompactButton(Gtk.Widget):
     __gtype_name__ = 'EtkCompactButton'
     __gsignals__ = {'clicked':
-                        (gobject.SIGNAL_RUN_FIRST | gobject.SIGNAL_ACTION,
-                         gobject.TYPE_NONE,
+                        (GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+                         None,
                          tuple())}
     __gproperties__ = {'icon-name-normal':
-                           (gobject.TYPE_STRING,
+                           (GObject.TYPE_STRING,
                             'icon name normal',
                             'icon name normal',
                             '',
-                            gobject.PARAM_READWRITE),
+                            GObject.PARAM_READWRITE),
                        'icon-name-prelight':
-                           (gobject.TYPE_STRING,
+                           (GObject.TYPE_STRING,
                             'icon name prelight',
                             'icon name prelight',
                             '',
-                            gobject.PARAM_READWRITE),
+                            GObject.PARAM_READWRITE),
                        'icon-name-active':
-                           (gobject.TYPE_STRING,
+                           (GObject.TYPE_STRING,
                             'icon name active',
                             'icon name active',
                             '',
-                            gobject.PARAM_READWRITE),
+                            GObject.PARAM_READWRITE),
                        'size':
-                           (gobject.TYPE_UINT,
+                           (GObject.TYPE_UINT,
                             'size',
                             'size',
                             0,
-                            gobject.G_MAXUINT,
+                            GObject.G_MAXUINT,
                             16,
-                            gobject.PARAM_READWRITE),
+                            GObject.PARAM_READWRITE),
                        'has-frame':
-                           (gobject.TYPE_BOOLEAN,
+                           (GObject.TYPE_BOOLEAN,
                             'has frame',
                             'has frame',
                             True,
-                            gobject.PARAM_READWRITE)}
+                            GObject.PARAM_READWRITE)}
 
     def __init__(self, icon_name_normal='', size=16, has_frame=True):
-        gtk.Widget.__init__(self)
-        self.set_flags(self.flags() | gtk.NO_WINDOW)
+        GObject.GObject.__init__(self)
+        self.set_flags(self.flags() | Gtk.NO_WINDOW)
 
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))
@@ -136,7 +136,7 @@ class CompactButton(gtk.Widget):
         self._icon_name_prelight = value
         self._icon_name_active = value
 
-        if self.flags() & gtk.REALIZED:
+        if self.get_realized():
             self._refresh_icons()
             self.queue_resize()
 
@@ -147,7 +147,7 @@ class CompactButton(gtk.Widget):
         self._icon_name_prelight = value
         self._icon_name_active = value
 
-        if self.flags() & gtk.REALIZED:
+        if self.get_realized():
             self._refresh_icons()
             self.queue_resize()
 
@@ -157,7 +157,7 @@ class CompactButton(gtk.Widget):
     def set_icon_name_active(self, value):
         self._icon_name_active = value
 
-        if self.flags() & gtk.REALIZED:
+        if self.get_realized():
             self._refresh_icons()
             self.queue_resize()
 
@@ -177,35 +177,35 @@ class CompactButton(gtk.Widget):
     # GtkWidget
     ############################################################################
     def do_realize(self):
-        gtk.Widget.do_realize(self)
-        self._input_window = gdk.Window(self.get_parent_window(),
+        Gtk.Widget.do_realize(self)
+        self._input_window = Gdk.Window(self.get_parent_window(),
                                         x=self.allocation.x,
                                         y=self.allocation.y,
                                         width=self.allocation.width,
                                         height=self.allocation.height,
-                                        window_type=gdk.WINDOW_CHILD,
-                                        wclass=gdk.INPUT_ONLY,
+                                        window_type=Gdk.WINDOW_CHILD,
+                                        wclass=Gdk.INPUT_ONLY,
                                         visual=self.get_visual(),
                                         colormap=self.get_colormap(),
-                                        event_mask=(gdk.ENTER_NOTIFY_MASK |
-                                                    gdk.LEAVE_NOTIFY_MASK |
-                                                    gdk.BUTTON_PRESS_MASK |
-                                                    gdk.BUTTON_RELEASE_MASK))
+                                        event_mask=(Gdk.EventMask.ENTER_NOTIFY_MASK |
+                                                    Gdk.EventMask.LEAVE_NOTIFY_MASK |
+                                                    Gdk.EventMask.BUTTON_PRESS_MASK |
+                                                    Gdk.EventMask.BUTTON_RELEASE_MASK))
         self._input_window.set_user_data(self)
         self._refresh_icons()
 
     def do_unrealize(self):
         self._input_window.set_user_data(None)
         self._input_window.destroy()
-        gtk.Widget.do_unrealize(self)
+        Gtk.Widget.do_unrealize(self)
 
     def do_map(self):
         self._input_window.show()
-        gtk.Widget.do_map(self)
+        Gtk.Widget.do_map(self)
 
     def do_unmap(self):
         self._input_window.hide()
-        gtk.Widget.do_unmap(self)
+        Gtk.Widget.do_unmap(self)
 
     def do_size_request(self, requisition):
         requisition.width = self._size
@@ -214,20 +214,20 @@ class CompactButton(gtk.Widget):
     def do_size_allocate(self, allocation):
         self.allocation = allocation
 
-        if self.flags() & gtk.REALIZED:
+        if self.get_realized():
             self._input_window.move_resize(*self.allocation)
 
     def do_expose_event(self, event):
         # Draw icon
-        if self.state == gtk.STATE_NORMAL:
+        if self.state == Gtk.StateType.NORMAL:
             pixbuf = self._icon_normal
             x = self.allocation.x
             y = self.allocation.y
-        elif self.state == gtk.STATE_PRELIGHT:
+        elif self.state == Gtk.StateType.PRELIGHT:
             pixbuf = self._icon_prelight
             x = self.allocation.x
             y = self.allocation.y
-        elif self.state == gtk.STATE_ACTIVE:
+        elif self.state == Gtk.StateType.ACTIVE:
             pixbuf = self._icon_active
             x = self.allocation.x + 1
             y = self.allocation.y + 1
@@ -235,7 +235,7 @@ class CompactButton(gtk.Widget):
         event.window.draw_pixbuf(self.style.base_gc[self.state], pixbuf, 0, 0, x, y)
 
         # Draw frame
-        if self._has_frame and self.state != gtk.STATE_NORMAL:
+        if self._has_frame and self.state != Gtk.StateType.NORMAL:
             event.window.draw_rectangle(self.style.dark_gc[self.state], False,
                                         self.allocation.x,
                                         self.allocation.y,
@@ -246,26 +246,26 @@ class CompactButton(gtk.Widget):
 
     def do_enter_notify_event(self, event):
         self._entered = True
-        self.set_state(gtk.STATE_PRELIGHT)
+        self.set_state(Gtk.StateType.PRELIGHT)
         self.queue_draw()
         return True
 
     def do_leave_notify_event(self, event):
         self._entered = False
-        self.set_state(gtk.STATE_NORMAL)
+        self.set_state(Gtk.StateType.NORMAL)
         self.queue_draw()
         return True
 
     def do_button_press_event(self, event):
         if event.button == 1:
-            self.set_state(gtk.STATE_ACTIVE)
+            self.set_state(Gtk.StateType.ACTIVE)
             self.queue_draw()
 
         return True
 
     def do_button_release_event(self, event):
         if event.button == 1 and self._entered == True:
-            self.set_state(gtk.STATE_PRELIGHT)
+            self.set_state(Gtk.StateType.PRELIGHT)
             self.emit('clicked')
             self.queue_draw()
 

--- a/etkdocking/compactbutton.py
+++ b/etkdocking/compactbutton.py
@@ -212,10 +212,10 @@ class CompactButton(Gtk.Widget):
 
     def do_map(self):
         self._input_window.show()
-        self._input_window.set_mapped(True)
+        self.set_mapped(True)
 
     def do_unmap(self):
-        self._input_window.set_mapped(False)
+        self.set_mapped(False)
         self._input_window.hide()
 
     def do_size_request(self, requisition):

--- a/etkdocking/compactbutton.py
+++ b/etkdocking/compactbutton.py
@@ -35,6 +35,17 @@ from .util import load_icon
 
 
 class CompactButton(Gtk.Widget):
+    """Compact minimize, maximize, list, close, and restore button Widget.
+
+    A button widget to add compact buttons to the tabs of a DockGroup.
+
+    To use:
+    >>> min_button = CompactButton('compact-minimize')
+    >>> def on_min_button_clicked():
+    >>>     pass
+    >>> min_button.connect('clicked', on_min_button_clicked)
+
+    """
     __gtype_name__ = 'EtkCompactButton'
     __gsignals__ = {'clicked':
                         (GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
@@ -93,6 +104,9 @@ class CompactButton(Gtk.Widget):
     # Convenience
     ############################################################################
     def _refresh_icons(self):
+        """Used to reload the button icon after the widget is realized.
+
+        """
         self._icon_normal = load_icon(self._icon_name_normal, self._size)
 
         if self._icon_name_prelight == self._icon_name_normal:
@@ -109,6 +123,15 @@ class CompactButton(Gtk.Widget):
     # GObject
     ############################################################################
     def do_get_property(self, pspec):
+        """Gets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): A property of the CompactButton.
+
+        Returns:
+            The parameter value.
+
+        """
         if pspec.name == 'icon-name-normal':
             return self.get_icon_name_normal()
         elif pspec.name == 'icon-name-prelight':
@@ -121,6 +144,13 @@ class CompactButton(Gtk.Widget):
             return self.get_has_frame()
 
     def do_set_property(self, pspec, value):
+        """Sets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): The property of the CompactButton to set.
+            value: the value to set.
+
+        """
         if pspec.name == 'icon-name-normal':
             self.set_icon_name_normal(value)
         elif pspec.name == 'icon-name-prelight':
@@ -133,9 +163,21 @@ class CompactButton(Gtk.Widget):
             self.set_has_frame(value)
 
     def get_icon_name_normal(self):
+        """Gets the name of the normal icon.
+
+        Returns:
+            string: The name of the normal icon.
+
+        """
         return self._icon_name_normal
 
     def set_icon_name_normal(self, value):
+        """Sets the name of the normal icon.
+
+        Args:
+            value (string): The name to set.
+
+        """
         self._icon_name_normal = value
         self._icon_name_prelight = value
         self._icon_name_active = value
@@ -145,9 +187,25 @@ class CompactButton(Gtk.Widget):
             self.queue_resize()
 
     def get_icon_name_prelight(self):
+        """Gets the name of the prelight icon.
+
+        The prelight icon is the icon displayed when the pointer is over it.
+
+        Returns:
+            string: The name of the prelight icon.
+
+        """
         return self._icon_name_prelight
 
     def set_icon_name_prelight(self, value):
+        """Sets the name of the prelight icon.
+
+        The prelight icon is the icon displayed when the pointer is over it.
+
+        Args:
+            value: The name to set.
+
+        """
         self._icon_name_prelight = value
         self._icon_name_active = value
 
@@ -156,9 +214,25 @@ class CompactButton(Gtk.Widget):
             self.queue_resize()
 
     def get_icon_name_active(self):
+        """Get the icon name when active.
+
+        The active icon is the icon displayed when the button is pressed or active.
+
+        Returns:
+            string: The name of the active icon.
+
+        """
         return self._icon_name_active
 
     def set_icon_name_active(self, value):
+        """Set the name of the active icon.
+
+        The active icon is the icon displayed when the button is pressed or active.
+
+        Args:
+            value: The name to set.
+
+        """
         self._icon_name_active = value
 
         if self.get_realized():
@@ -166,21 +240,48 @@ class CompactButton(Gtk.Widget):
             self.queue_resize()
 
     def get_size(self):
+        """Gets the size of the icon.
+
+        Returns:
+            int: The icon size.
+
+        """
         return self._size
 
     def set_size(self, value):
+        """Sets the size of the icon.
+
+        Args:
+            value (int): The size of the icon.
+
+        """
         self._size = value
 
     def get_has_frame(self):
+        """Gets whether the CompactButton has a frame.
+
+        Returns:
+            bool: Whether it has a frame.
+
+        """
         return self._has_frame
 
     def set_has_frame(self, value):
+        """Sets whether the CompactButton has a frame.
+
+        Args:
+            value (bool): Whether it has a frame.
+
+        """
         self._has_frame = value
 
     ############################################################################
     # GtkWidget
     ############################################################################
     def do_realize(self):
+        """Associate a Gdk.Window with the CompactButton widget.
+
+        """
         allocation = self.get_allocation()
         attr = Gdk.WindowAttr()
         attr.x = allocation.x
@@ -188,43 +289,153 @@ class CompactButton(Gtk.Widget):
         attr.width = allocation.width
         attr.height = allocation.height
         attr.window_type = Gdk.WindowType.CHILD
-        attr.wclass = Gdk.WindowWindowClass.INPUT_OUTPUT
+        attr.wclass = Gdk.WindowWindowClass.INPUT_ONLY
         attr.visual = self.get_visual()
-        attr.event_mask = (self.get_events() |
-                                Gdk.EventMask.EXPOSURE_MASK |
-                                Gdk.EventMask.POINTER_MOTION_MASK |
-                                Gdk.EventMask.BUTTON_PRESS_MASK |
-                                Gdk.EventMask.BUTTON_RELEASE_MASK
-                                )
+        attr.event_mask = (Gdk.EventMask.EXPOSURE_MASK |
+                           Gdk.EventMask.POINTER_MOTION_MASK |
+                           Gdk.EventMask.BUTTON_PRESS_MASK |
+                           Gdk.EventMask.BUTTON_RELEASE_MASK
+                           )
         attr_mask = (Gdk.WindowAttributesType.X |
                            Gdk.WindowAttributesType.Y |
                            Gdk.WindowAttributesType.WMCLASS |
                            Gdk.WindowAttributesType.VISUAL
                            )
         self._input_window = Gdk.Window(self.get_parent_window(), attr, attr_mask)
-        self._input_window.set_user_data(self)
+        self._input_window.set_/ser_data(self)
         self._refresh_icons()
+        self.set_realized(True)
 
     def do_unrealize(self):
+        """Break the association with the Gdk.Window.
+
+        This custom widget override is optional.
+
+        """
         self._input_window.set_user_data(None)
         self._input_window.destroy()
         Gtk.Widget.do_unrealize(self)
 
     def do_map(self):
-        self._input_window.show()
+        """Causes the widget to be mapped if it isn't already.
+
+        This custom widget override is optional.
+
+        """
         self.set_mapped(True)
+        self._input_window.show()
 
     def do_unmap(self):
+        """Causes the widget to be unmapped if it is currently mapped.
+
+        This custom widget override is optional.
+
+        """
+        self.set_mapped(False)
         self._input_window.hide()
-        Gtk.Widget.do_unmap(self)
+
+    def do_get_request_mode(self):
+        """Returns the preferred widget layout.
+
+        Returns whether the container prefers a height-for-width or a
+        width-for-height layout. CompactButton doesn't trade width for height
+        or height for width so we return CONSTANT_SIZE.
+
+        Returns:
+            Gtk.SizeRequestMode: the constant size request mode
+
+        """
+        return Gtk.SizeRequestMode.CONSTANT_SIZE
+
+    def do_get_preferred_height(self):
+        """Calculates the widget's initial minimum and natural height.
+
+        While this call is specific to width-for-height requests (that we
+        requested not to get) we cannot be certain that our wishes are granted,
+        so we must implement this method as well. Returns the icon size as the
+        minimum and natural height.
+
+        Returns:
+             int: minimum height, natural height
+
+        """
+        icon_size = self.get_size()
+        return icon_size, icon_size
+
+    def do_get_preferred_width(self):
+        """Calculates the widget's initial minimum and natural width.
+
+        While this call is specific to width-for-height requests (that we requested
+        not to get) we cannot be certain that our wishes are granted, so
+        we must implement this method as well. Returns the icon size as the
+        minimum and natural width.
+
+        Returns:
+            int: minimum width, natural width
+
+        """
+        icon_size = self.get_size()
+        return icon_size, icon_size
+
+    def do_get_preferred_height_for_width(self, width):
+        """If given width, returns the minimum and natural height.
+
+        Returns the container's minimum and natural height if given the
+        specified width. While this call is specific to height-for-width
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_height.
+
+        Args:
+            width (int): The given width. Ignored.
+
+        Returns:
+            int: minimum height, natural height
+
+        """
+        return self.do_get_preferred_height()
+
+    def do_get_preferred_width_for_height(self, height):
+        """If given height, returns the minimum and natural width.
+
+        Returns the container's minimum and natural width if given the
+        specified height. While this call is specific to width-for-height
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_width.
+
+        Args:
+            height (int): The given height. Ignored.
+
+        Returns:
+            int: minimum width, natural width
+
+        """
+        return self.do_get_preferred_width()
 
     def do_size_allocate(self, allocation):
+        """Position the CompactButton, given the allocation.
+
+        Args:
+            allocation (Gdk.Rectangle): The position and size to be allocated
+
+        """
         self.allocation = allocation
 
         if self.get_realized():
             self._input_window.move_resize(allocation.x, allocation.y, allocation.width, allocation.height)
 
     def do_draw(self, cr):
+        """Draw on supplied Cairo Context.
+
+        Draws the icon and frame of the CompactButton.
+
+        Args:
+            cr (cairo.Context): The context to draw on
+
+        """
         # Draw icon
         if self.state == Gtk.StateFlags.PRELIGHT:
             pixbuf = self._icon_prelight
@@ -258,18 +469,45 @@ class CompactButton(Gtk.Widget):
             )
 
     def do_enter_notify_event(self, event):
+        """Called when the pointer has entered the widget.
+
+        Args:
+            event (Gdk.EnterCrossing): The event that is generated when the pointer enters.
+
+        Returns:
+            True.
+
+        """
         self._entered = True
         self.set_state(Gtk.StateFlags.PRELIGHT)
         self.queue_draw()
         return True
 
     def do_leave_notify_event(self, event):
+        """Called when the pointer has entered the widget.
+
+        Args:
+            event (Gdk.EventCrossing): The event that is generated when the pointer leaves.
+
+        Returns:
+            True.
+
+        """
         self._entered = False
         self.set_state(Gtk.StateFlags.NORMAL)
         self.queue_draw()
         return True
 
     def do_button_press_event(self, event):
+        """Called wen the pointer button is clicked.
+
+        Args:
+            event (Gdk.EventButton): Button press event.
+
+        Returns:
+            True.
+
+        """
         if event.button == 1:
             self.set_state(Gtk.StateFlags.ACTIVE)
             self.queue_draw()
@@ -277,7 +515,16 @@ class CompactButton(Gtk.Widget):
         return True
 
     def do_button_release_event(self, event):
-        if event.button == 1 and self._entered == True:
+        """Called when the pointer button is released.
+
+        Args:
+            event (Gdk.EventButton): Button release event.
+
+        Returns:
+            True.
+
+        """
+        if event.button == 1 and self._entered:
             self.set_state(Gtk.StateFlags.PRELIGHT)
             self.emit('clicked')
             self.queue_draw()

--- a/etkdocking/compactbutton.py
+++ b/etkdocking/compactbutton.py
@@ -74,7 +74,7 @@ class CompactButton(Gtk.Widget):
                             GObject.ParamFlags.READWRITE)}
 
     def __init__(self, icon_name_normal='', size=16, has_frame=True):
-        GObject.GObject.__init__(self)
+        Gtk.Widget.__init__(self)
         # TODO this is PyGTK specific, and no equivalent in PyGi. Does it need to be GInitiallyUnowned?
         # self.set_flags(self.flags() | Gtk.NO_WINDOW)
 

--- a/etkdocking/compactbutton.py
+++ b/etkdocking/compactbutton.py
@@ -23,9 +23,10 @@ from __future__ import absolute_import
 from builtins import hex
 from logging import getLogger
 
-from gi.repository import GObject
-from gi.repository import Gtk
-import Gtk.gdk as gdk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk, GObject
 
 from .util import load_icon
 

--- a/etkdocking/dnd.py
+++ b/etkdocking/dnd.py
@@ -36,7 +36,8 @@ DRAG_TARGET_ITEM_LIST = Gtk.TargetEntry.new("x-etk-docking/item-list", Gtk.Targe
 
 
 class DockDragContext(object):
-    '''
+    """Stores drag information during a drag operation.
+
     As we can't reliably use drag_source_set to initiate a drag operation
     (there's just to much information locked away in C structs - GtkDragSourceSite,
     GtkDragSourceInfo, GtkDragDestSite, GtkDragDestInfo, ... - that are not
@@ -44,7 +45,8 @@ class DockDragContext(object):
 
     This class is also used to store extra information about a drag operation
     in progress not available in the C structs mentioned above.
-    '''
+
+    """
     __slots__ = ['dragging',  # are we dragging or not (bool)
                  'dragged_object',  # object being dragged
                  'source_x',  # x coordinate starting a potential drag
@@ -67,6 +69,9 @@ class DockDragContext(object):
 
 
 class Placeholder(Gtk.DrawingArea):
+    """Acts as a placeholder when the DockLayout doesn't display any childrenA.
+
+    """
     __gtype_name__ = 'EtkDockPlaceholder'
 
     def __init__(self):
@@ -81,8 +86,9 @@ class Placeholder(Gtk.DrawingArea):
 
 
 class PlaceHolderWindow(Gtk.Window):
-    '''
-    The etk.dnd.PlaceHolderWindow is a Gtk.Window that can highlight an area
+    """Window that can highlight an area on screen for DnD.
+
+    The PlaceHolderWindow is a Gtk.Window that can highlight an area
     on screen. When a PlaceHolderWindow has no child widget an undecorated
     utility popup is shown drawing a transparent highlighting rectangle around
     the desired area. The location and size of the highlight rectangle can
@@ -95,7 +101,8 @@ class PlaceHolderWindow(Gtk.Window):
     This is used by the drag and drop implementation to mark a valid destination
     for the drag and drop operation while dragging and as the container window
     for teared off floating items.
-    '''
+
+    """
     __gtype_name__ = 'EtkDockPlaceHolderWindow'
 
     def __init__(self):
@@ -109,6 +116,18 @@ class PlaceHolderWindow(Gtk.Window):
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))
 
     def _create_shape(self, da, ctx):
+        """Draws a mask over the window.
+
+        This method is called by draw signal which is setup in the
+        do_size_allocate method to draw a mask on the window for highlighting.
+
+        Args:
+            da (Gtk.DrawingArea): The drawing area that is passed from the draw
+                signal.
+            ctx (cairo.Context): The cairo context that is passed from
+                the draw signal.
+
+        """
         width, height = self.get_size()
         mask = cairo.SolidPattern(255, 255, 255, 0)
         ctx.set_source_rgba(0, 0, 0, 1)
@@ -116,24 +135,42 @@ class PlaceHolderWindow(Gtk.Window):
         ctx.mask(mask)
 
     ############################################################################
-    # GtkWidget
+    # Gtk.Widget
     ############################################################################
     def do_realize(self):
+        """Creates the Gdk window resources for the PlaceHolderWindow.
+
+        """
         Gtk.Window.do_realize(self)
 
     def do_unrealize(self):
+        """Clears the Gdk window resources for the PlaceHolderWindow.
+
+        """
         Gtk.Window.do_unrealize(self)
 
     def do_size_allocate(self, allocation):
+        """Assigns a size and position to the PlaceHolderWindow.
+
+        Args:
+            allocation (Gdk.Rectangle): Position and size allocated.
+
+        """
         self.log.debug('%s' % allocation)
         Gtk.Window.do_size_allocate(self, allocation)
         drawingarea = Gtk.DrawingArea
         drawingarea.connect("draw", self._create_shape)
 
     ############################################################################
-    # GtkContainer
+    # Gtk.Container
     ############################################################################
     def do_add(self, widget):
+        """Called when the given widget is added to the PlaceHolderWindow.
+
+        Args:
+            widget (Gtk.Window): The widget to add.
+
+        """
         self.set_decorated(True)
         self.reset_shapes()
         Gtk.Window.add(self, widget)
@@ -142,6 +179,15 @@ class PlaceHolderWindow(Gtk.Window):
     # EtkPlaceHolderWindow
     ############################################################################
     def move_resize(self, x, y, width, height):
+        """Move and resize the PlaceHolderWindow.
+
+        Args:
+            x (int): x position to move the window to.
+            y (int): y position to move the window to.
+            width (int): Width to make the window.
+            height (int): Height to make the window.
+
+        """
         self.log.debug('%s, %s, %s, %s' % (x, y, width, height))
 
         self.move(x, y)

--- a/etkdocking/dnd.py
+++ b/etkdocking/dnd.py
@@ -24,8 +24,10 @@ from builtins import object
 from builtins import hex
 from logging import getLogger
 
-from gi.repository import Gtk
-import Gtk.gdk as gdk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk, GObject
 
 DRAG_TARGET_ITEM_LIST = ('x-etk-docking/item-list', Gtk.TargetFlags.SAME_APP, 0)
 

--- a/etkdocking/dnd.py
+++ b/etkdocking/dnd.py
@@ -29,7 +29,8 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GObject
 
-DRAG_TARGET_ITEM_LIST = ('x-etk-docking/item-list', Gtk.TargetFlags.SAME_APP, 0)
+
+DRAG_TARGET_ITEM_LIST = Gtk.TargetEntry.new("x-etk-docking/item-list", Gtk.TargetFlags.SAME_APP, 0)
 
 
 class DockDragContext(object):

--- a/etkdocking/dnd.py
+++ b/etkdocking/dnd.py
@@ -24,10 +24,10 @@ from builtins import object
 from builtins import hex
 from logging import getLogger
 
-import gtk
-import gtk.gdk as gdk
+from gi.repository import Gtk
+import Gtk.gdk as gdk
 
-DRAG_TARGET_ITEM_LIST = ('x-etk-docking/item-list', gtk.TARGET_SAME_APP, 0)
+DRAG_TARGET_ITEM_LIST = ('x-etk-docking/item-list', Gtk.TargetFlags.SAME_APP, 0)
 
 
 class DockDragContext(object):
@@ -61,7 +61,7 @@ class DockDragContext(object):
         self.offset_y = None
 
 
-class Placeholder(gtk.DrawingArea):
+class Placeholder(Gtk.DrawingArea):
     __gtype_name__ = 'EtkDockPlaceholder'
 
     def do_expose_event(self, expose):
@@ -75,9 +75,9 @@ class Placeholder(gtk.DrawingArea):
         c.stroke()
 
 
-class PlaceHolderWindow(gtk.Window):
+class PlaceHolderWindow(Gtk.Window):
     '''
-    The etk.dnd.PlaceHolderWindow is a gtk.Window that can highlight an area
+    The etk.dnd.PlaceHolderWindow is a Gtk.Window that can highlight an area
     on screen. When a PlaceHolderWindow has no child widget an undecorated
     utility popup is shown drawing a transparent highlighting rectangle around
     the desired area. The location and size of the highlight rectangle can
@@ -94,10 +94,10 @@ class PlaceHolderWindow(gtk.Window):
     __gtype_name__ = 'EtkDockPlaceHolderWindow'
 
     def __init__(self):
-        gtk.Window.__init__(self, gtk.WINDOW_POPUP)
+        GObject.GObject.__init__(self, Gtk.WindowType.POPUP)
         self.set_decorated(False)
         self.set_skip_taskbar_hint(True)
-        self.set_type_hint(gdk.WINDOW_TYPE_HINT_UTILITY)
+        self.set_type_hint(Gdk.WindowTypeHint.UTILITY)
         # TODO: self.set_transient_for(???.get_toplevel())
 
         # Initialize logging
@@ -107,11 +107,11 @@ class PlaceHolderWindow(gtk.Window):
         self._gc = None
 
     def _create_shape(self, width, height):
-        black = gdk.Color(red=0, green=0, blue=0, pixel=1)
-        white = gdk.Color(red=255, green=255, blue=255, pixel=0)
+        black = Gdk.Color(red=0, green=0, blue=0, pixel=1)
+        white = Gdk.Color(red=255, green=255, blue=255, pixel=0)
 
-        pm = gdk.Pixmap(self.window, width, height, 1)
-        gc = gdk.GC(pm)
+        pm = Gdk.Pixmap(self.window, width, height, 1)
+        gc = Gdk.GC(pm)
         gc.set_background(white)
         gc.set_foreground(white)
         pm.draw_rectangle(gc, True, 0, 0, width, height)
@@ -126,22 +126,22 @@ class PlaceHolderWindow(gtk.Window):
     # GtkWidget
     ############################################################################
     def do_realize(self):
-        gtk.Window.do_realize(self)
-        self._gc = self.style.bg_gc[gtk.STATE_SELECTED]
+        Gtk.Window.do_realize(self)
+        self._gc = self.style.bg_gc[Gtk.StateType.SELECTED]
 
     def do_unrealize(self):
         self._gc = None
-        gtk.Window.do_unrealize(self)
+        Gtk.Window.do_unrealize(self)
 
     def do_size_allocate(self, allocation):
         self.log.debug('%s' % allocation)
-        gtk.Window.do_size_allocate(self, allocation)
+        Gtk.Window.do_size_allocate(self, allocation)
 
         self._create_shape(allocation.width, allocation.height)
 
     def do_expose_event(self, event):
         self.log.debug('%s' % event)
-        gtk.Window.do_expose_event(self, event)
+        Gtk.Window.do_expose_event(self, event)
 
         width, height = self.get_size()
         self.window.draw_rectangle(self._gc, False, 0, 0, width - 1, height - 1)
@@ -154,7 +154,7 @@ class PlaceHolderWindow(gtk.Window):
     def do_add(self, widget):
         self.set_decorated(True)
         self.reset_shapes()
-        gtk.Window.add(self, widget)
+        Gtk.Window.add(self, widget)
 
     ############################################################################
     # EtkPlaceHolderWindow

--- a/etkdocking/dnd.py
+++ b/etkdocking/dnd.py
@@ -97,7 +97,7 @@ class PlaceHolderWindow(Gtk.Window):
     __gtype_name__ = 'EtkDockPlaceHolderWindow'
 
     def __init__(self):
-        GObject.GObject.__init__(self, Gtk.WindowType.POPUP)
+        Gtk.Window.__init__(self, Gtk.WindowType.POPUP)
         self.set_decorated(False)
         self.set_skip_taskbar_hint(True)
         self.set_type_hint(Gdk.WindowTypeHint.UTILITY)

--- a/etkdocking/dockframe.py
+++ b/etkdocking/dockframe.py
@@ -23,19 +23,19 @@ from __future__ import absolute_import
 from builtins import hex
 from logging import getLogger
 
-import gtk
-import gtk.gdk as gdk
+from gi.repository import Gtk
+import Gtk.gdk as gdk
 
 
-class DockFrame(gtk.Bin):
+class DockFrame(Gtk.Bin):
     '''
-    The etk.DockFrame widget is a gtk.Bin that acts as the toplevel widget
+    The etk.DockFrame widget is a Gtk.Bin that acts as the toplevel widget
     for a dock layout hierarchy.
     '''
     __gtype_name__ = 'EtkDockFrame'
 
     def __init__(self):
-        gtk.Bin.__init__(self)
+        GObject.GObject.__init__(self)
 
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))
@@ -50,21 +50,21 @@ class DockFrame(gtk.Bin):
         requisition.width = 0
         requisition.height = 0
 
-        if self.child and self.child.flags() & gtk.VISIBLE:
-            (requisition.width, requisition.height) = self.child.size_request()
+        if self.get_child() and self.get_child().flags() & Gtk.VISIBLE:
+            (requisition.width, requisition.height) = self.get_child().size_request()
             requisition.width += self.border_width * 2
             requisition.height += self.border_width * 2
 
     def do_size_allocate(self, allocation):
         self.allocation = allocation
 
-        if self.child and self.child.flags() & gtk.VISIBLE:
-            child_allocation = gdk.Rectangle()
+        if self.get_child() and self.get_child().flags() & Gtk.VISIBLE:
+            child_allocation = ()
             child_allocation.x = allocation.x + self.border_width
             child_allocation.y = allocation.y + self.border_width
             child_allocation.width = allocation.width - (2 * self.border_width)
             child_allocation.height = allocation.height - (2 * self.border_width)
-            self.child.size_allocate(child_allocation)
+            self.get_child().size_allocate(child_allocation)
 
     ############################################################################
     # EtkDockFrame

--- a/etkdocking/dockframe.py
+++ b/etkdocking/dockframe.py
@@ -23,8 +23,10 @@ from __future__ import absolute_import
 from builtins import hex
 from logging import getLogger
 
-from gi.repository import Gtk
-import Gtk.gdk as gdk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GObject, Gdk
 
 
 class DockFrame(Gtk.Bin):

--- a/etkdocking/dockframe.py
+++ b/etkdocking/dockframe.py
@@ -30,10 +30,10 @@ from gi.repository import Gtk, GObject, Gdk
 
 
 class DockFrame(Gtk.Bin):
-    '''
+    """
     The etk.DockFrame widget is a Gtk.Bin that acts as the toplevel widget
     for a dock layout hierarchy.
-    '''
+    """
     __gtype_name__ = 'EtkDockFrame'
 
     def __init__(self):
@@ -50,39 +50,52 @@ class DockFrame(Gtk.Bin):
     # GtkContainer
     ############################################################################
     def do_child_type(self):
-        """Indicates that this container accepts any GTK+ widget."""
+        """Indicates that this container accepts any GTK+ widget.
+
+        """
         return Gtk.Widget.get_type()
 
     def do_forall(self, include_internals, callback, *callback_data):
         """Invokes the given callback on the child widget, with the given data.
 
-        @param include_internals Whether to run on internal children as well, as
-                                 boolean. Ignored, as there are no internal
-                                 children.
-        @param callback The callback to call on the child, as Gtk.Callback
-        @param callback_data The parameters to pass to the callback, as object
-                             or None
+        Args:
+            include_internals (bool): Run on internal children
+            callback (Gtk.Callback): The callback to call on each child
+            callback_data (object or None): The parameters to pass to the
+                callback
+
         """
         child = self.get_child()
         if include_internals and child:
             callback(child, *callback_data)
 
     ############################################################################
-    # GtkWidget
+    # Gtk.Widget
     ############################################################################
     def do_get_request_mode(self):
-        """Returns whether the DockFrame prefers a height-for-width or a
+        """Returns the DockFrame's preferred layout for size determination.
+
+        Returns whether the DockFrame prefers a height-for-width or a
         width-for-height layout. DockFrame doesn't trade width for height or
         height for width so we return CONSTANT_SIZE.
+
+        Returns:
+            Gtk.SizeRequestMode: The constant size request mode.
+
         """
         return Gtk.SizeRequestMode.CONSTANT_SIZE
 
     def do_get_preferred_height(self):
-        """Calculates the DockFrame's initial minimum and natural height. While
-        this call is specific to width-for-height requests (that we requested
-        not to get) we cannot be certain that our wishes are granted, so we
-        must implement this method as well. Returns the preferred height of the
-        child widget with padding added for the border width.
+        """Calculates the DockFrame's initial minimum and natural height.
+
+        While this call is specific to width-for-height requests (that we
+        requested not to get) we cannot be certain that our wishes are granted,
+        so we must implement this method as well. Returns the preferred height
+        of the child widget with padding added for the border width.
+
+        Returns:
+            int: minimum height, natural height.
+
         """
         minimum_height = 0
         natural_height = 0
@@ -94,11 +107,16 @@ class DockFrame(Gtk.Bin):
         return minimum_height, natural_height
 
     def do_get_preferred_width(self):
-        """Calculates the DockFrame's initial minimum and natural width. While
-        this call is specific to width-for-height requests (that we requested
-        not to get) we cannot be certain that our wishes are granted, so
-        we must implement this method as well. Returns the preferred width of
-        the child widget with padding added for the border width.
+        """Calculates the DockFrame's initial minimum and natural width.
+
+        While this call is specific to width-for-height requests (that we
+        requested not to get) we cannot be certain that our wishes are granted,
+        so we must implement this method as well. Returns the preferred width
+        of the child widget with padding added for the border width.
+
+        Returns:
+            int: minimum width, natural width.
+
         """
         minimum_width = 0
         natural_width = 0
@@ -110,30 +128,47 @@ class DockFrame(Gtk.Bin):
         return minimum_width, natural_width
 
     def do_get_preferred_height_for_width(self, width):
-        """Returns this DockFrame's minimum and natural height if it would be
-        given the specified width. While this call is specific to
-        height-for-width requests (that we requested not to get) we cannot be
-        certain that our wishes are granted, so we must implement this method
-        as well. Since we really want to be the same size always, we simply
-        return do_get_preferred_height.
+        """Returns this DockFrame's minimum and natural height, given width.
 
-        @param width The given width, as int. Ignored.
+        If the DockFrame is given the specified width, calculate the minimum
+        and natural height. While this call is specific to height-for-width
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_height.
+
+        Args:
+            width (int): The given width, ignored.
+
         """
         return self.do_get_preferred_height()
 
     def do_get_preferred_width_for_height(self, height):
-        """Returns this DockFrame's minimum and natural width if it would be
-        given the specified height. While this call is specific to
-        width-for-height requests (that we requested not to get) we cannot be
-        certain that our wishes are granted, so we must implement this method
-        as well. Since we really want to be the same size always, we simply
-        return do_get_preferred_width.
+        """Returns this DockFrame's minimum and natural width, given height.
 
-        @param height The given height, as int. Ignored.
+        If the DockFrame is given the specified height, calculate the minimum
+        and natural width. While this call is specific to width-for-height
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_width.
+
+        Args:
+            height (int): The given height, ignored.
+
         """
         return self.do_get_preferred_width()
 
     def do_size_allocate(self, allocation):
+        """Assigns a size and position to the child widgets.
+
+        Children may adjust the given allocation in the adjust_size_allocation
+        virtual method.
+
+        Args:
+            allocation (Gdk.Rectangle): Position and size allocated.
+
+        """
         self.border_width = self.get_border_width()
         child = self.get_child()
 
@@ -149,11 +184,11 @@ class DockFrame(Gtk.Bin):
     # EtkDockFrame
     ############################################################################
     def set_placeholder(self, placeholder):
-        """
-        Set a new placeholder widget on the frame. The placeholder is drawn on top
-        of the dock items.
+        """Set a new placeholder widget on the frame.
 
-        If a new placeholder is set, an existing placeholder is destroyed.
+        The placeholder is drawn on top of the dock items. If a new placeholder
+        is set, an existing placeholder is destroyed.
+
         """
         if self._placeholder:
             self._placeholder.unparent()

--- a/etkdocking/dockframe.py
+++ b/etkdocking/dockframe.py
@@ -37,7 +37,7 @@ class DockFrame(Gtk.Bin):
     __gtype_name__ = 'EtkDockFrame'
 
     def __init__(self):
-        GObject.GObject.__init__(self)
+        Gtk.Bin.__init__(self)
 
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))

--- a/etkdocking/dockframe.py
+++ b/etkdocking/dockframe.py
@@ -52,16 +52,16 @@ class DockFrame(Gtk.Bin):
         requisition.width = 0
         requisition.height = 0
 
-        if self.get_child() and self.get_child().flags() & Gtk.VISIBLE:
-            (requisition.width, requisition.height) = self.get_child().size_request()
+        if self.get_child() and self.get_child().props.visible:
+            (requisition.width, requisition.height) = self.child.size_request()
             requisition.width += self.border_width * 2
             requisition.height += self.border_width * 2
 
     def do_size_allocate(self, allocation):
-        self.allocation = allocation
+        self.border_width = self.get_border_width()
 
-        if self.get_child() and self.get_child().flags() & Gtk.VISIBLE:
-            child_allocation = ()
+        if self.get_child() and self.get_child().props.visible:
+            child_allocation = Gdk.Rectangle()
             child_allocation.x = allocation.x + self.border_width
             child_allocation.y = allocation.y + self.border_width
             child_allocation.width = allocation.width - (2 * self.border_width)

--- a/etkdocking/dockframe.py
+++ b/etkdocking/dockframe.py
@@ -44,29 +44,106 @@ class DockFrame(Gtk.Bin):
 
         # Internal housekeeping
         self._placeholder = None
+        self.border_width = 0
+
+    ############################################################################
+    # GtkContainer
+    ############################################################################
+    def do_child_type(self):
+        """Indicates that this container accepts any GTK+ widget."""
+        return Gtk.Widget.get_type()
+
+    def do_forall(self, include_internals, callback, *callback_data):
+        """Invokes the given callback on the child widget, with the given data.
+
+        @param include_internals Whether to run on internal children as well, as
+                                 boolean. Ignored, as there are no internal
+                                 children.
+        @param callback The callback to call on the child, as Gtk.Callback
+        @param callback_data The parameters to pass to the callback, as object
+                             or None
+        """
+        child = self.get_child()
+        if include_internals and child:
+            callback(child, *callback_data)
 
     ############################################################################
     # GtkWidget
     ############################################################################
-    def do_size_request(self, requisition):
-        requisition.width = 0
-        requisition.height = 0
+    def do_get_request_mode(self):
+        """Returns whether the DockFrame prefers a height-for-width or a
+        width-for-height layout. DockFrame doesn't trade width for height or
+        height for width so we return CONSTANT_SIZE.
+        """
+        return Gtk.SizeRequestMode.CONSTANT_SIZE
 
-        if self.get_child() and self.get_child().props.visible:
-            (requisition.width, requisition.height) = self.child.size_request()
-            requisition.width += self.border_width * 2
-            requisition.height += self.border_width * 2
+    def do_get_preferred_height(self):
+        """Calculates the DockFrame's initial minimum and natural height. While
+        this call is specific to width-for-height requests (that we requested
+        not to get) we cannot be certain that our wishes are granted, so we
+        must implement this method as well. Returns the preferred height of the
+        child widget with padding added for the border width.
+        """
+        minimum_height = 0
+        natural_height = 0
+        child = self.get_child()
+        if child and child.props.visible:
+            minimum_height, natural_height = child.get_preferred_height()
+            minimum_height += self.border_width * 2
+            natural_height += self.border_width * 2
+        return minimum_height, natural_height
+
+    def do_get_preferred_width(self):
+        """Calculates the DockFrame's initial minimum and natural width. While
+        this call is specific to width-for-height requests (that we requested
+        not to get) we cannot be certain that our wishes are granted, so
+        we must implement this method as well. Returns the preferred width of
+        the child widget with padding added for the border width.
+        """
+        minimum_width = 0
+        natural_width = 0
+        child = self.get_child()
+        if child and child.props.visible:
+            minimum_width, natural_width = child.get_preferred_width()
+            minimum_width += self.border_width * 2
+            natural_width += self.border_width * 2
+        return minimum_width, natural_width
+
+    def do_get_preferred_height_for_width(self, width):
+        """Returns this DockFrame's minimum and natural height if it would be
+        given the specified width. While this call is specific to
+        height-for-width requests (that we requested not to get) we cannot be
+        certain that our wishes are granted, so we must implement this method
+        as well. Since we really want to be the same size always, we simply
+        return do_get_preferred_height.
+
+        @param width The given width, as int. Ignored.
+        """
+        return self.do_get_preferred_height()
+
+    def do_get_preferred_width_for_height(self, height):
+        """Returns this DockFrame's minimum and natural width if it would be
+        given the specified height. While this call is specific to
+        width-for-height requests (that we requested not to get) we cannot be
+        certain that our wishes are granted, so we must implement this method
+        as well. Since we really want to be the same size always, we simply
+        return do_get_preferred_width.
+
+        @param height The given height, as int. Ignored.
+        """
+        return self.do_get_preferred_width()
 
     def do_size_allocate(self, allocation):
         self.border_width = self.get_border_width()
+        child = self.get_child()
 
-        if self.get_child() and self.get_child().props.visible:
+        if child and child.props.visible:
             child_allocation = Gdk.Rectangle()
             child_allocation.x = allocation.x + self.border_width
             child_allocation.y = allocation.y + self.border_width
             child_allocation.width = allocation.width - (2 * self.border_width)
             child_allocation.height = allocation.height - (2 * self.border_width)
-            self.get_child().size_allocate(child_allocation)
+            self.child.size_allocate(child_allocation)
 
     ############################################################################
     # EtkDockFrame

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -116,6 +116,7 @@ class DockGroup(Gtk.Container):
         self._spacing = 3
         self._available_width = 0
         self._decoration_area = Gdk.Rectangle()
+        self.weight = None
 
         self._tabs = []
         self._visible_tabs = []
@@ -1242,6 +1243,22 @@ class DockGroup(Gtk.Container):
         tab = self._tabs[self.item_num(item)]
         self._tabs.remove(tab)
         self._tabs.insert(position, tab)
+
+    def get_weight(self):
+        """
+        :return: the weight of the DockGroup.
+
+        Retrieves the weight of the DockGroup.
+        """
+        return self.weight
+
+    def set_weight(self, weight):
+        """
+        :param weight: the DockGroup's new orientation.
+
+        Sets the weight of the DockGroup.
+        """
+        self.weight = weight
 
     ############################################################################
     # Property notification signal handlers

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -112,7 +112,7 @@ class DockGroup(Gtk.Container):
         self._tab_state = Gtk.StateType.SELECTED
         self.dragcontext = DockDragContext()
 
-        Gtk.widget_push_composite_child()
+        Gtk.Widget.push_composite_child()
         self._list_button = CompactButton('compact-list')
         self._list_button.set_tooltip_text(_('Show list'))
         self._list_button.connect('clicked', self._on_list_button_clicked)
@@ -129,7 +129,7 @@ class DockGroup(Gtk.Container):
         self._tab_menu.attach_to_widget(self, None)
         self._list_menu = Gtk.Menu()
         self._list_menu.attach_to_widget(self._list_button, None)
-        Gtk.widget_pop_composite_child()
+        Gtk.Widget.pop_composite_child()
 
     def __len__(self):
         return len(self._tabs)

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -521,7 +521,6 @@ class DockGroup(Gtk.Container):
 
         # Draw frame
         style_context.save()
-        style_context.set_state(self.state)
         style_provider.load_from_data(bytes("* { border-width: {}; }".format(self._frame_width), "utf-8"))
         Gtk.render_frame(context=style_context, cr=cr, x=0.5, y=0.5, width=a.width, height=a.height)
         style_context.restore()

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -104,7 +104,7 @@ class DockGroup(Gtk.Container):
         self._frame_width = 1
         self._spacing = 3
         self._available_width = 0
-        self._decoration_area = ()
+        self._decoration_area = Gdk.Rectangle()
 
         self._tabs = []
         self._visible_tabs = []
@@ -159,6 +159,8 @@ class DockGroup(Gtk.Container):
         )
         self.window = Gdk.Window(self.get_parent_window(), attr, attr_mask)
         self.window.set_user_data(self)
+        # self.window.style = self.window.get_style_context()
+        # self.window.style.set_state(Gtk.StateFlags.NORMAL)
         self.set_window(self.window)
         self.set_realized(True)
 
@@ -174,26 +176,25 @@ class DockGroup(Gtk.Container):
         self._max_button.set_parent_window(self.window)
 
     def do_unrealize(self):
+        self.set_realized(False)
         self.window.set_user_data(None)
         self.window.destroy()
-        Gtk.Container.do_unrealize(self)
 
     def do_map(self):
-        Gtk.Container.do_map(self)
         self._list_button.show()
         self._min_button.show()
         self._max_button.show()
         self.window.show()
+        self.set_mapped(True)
 
     def do_unmap(self):
+        self.set_mapped(False)
         self._list_button.hide()
         self._min_button.hide()
         self._max_button.hide()
         self.window.hide()
-        Gtk.Container.do_unmap(self)
 
     def do_size_request(self, requisition):
-        Gtk.Container.do_size_request(self, requisition)
 
         # Start with a zero sized decoration area
         dw = dh = 0
@@ -377,10 +378,11 @@ class DockGroup(Gtk.Container):
         # Allocate space for the current *item*
         if self._current_tab:
             i_rect = Gdk.Rectangle()
-            ix = self._frame_width + self.border_width
-            iy = self._decoration_area.height + self.border_width
-            iw = max(allocation.width - (2 * self._frame_width) - (2 * self.border_width), 0)
-            ih = max(allocation.height - (2 * self._frame_width) - (2 * self.border_width) - 23, 0)
+            border_width = self.get_border_width()
+            ix = self._frame_width + border_width
+            iy = self._decoration_area.height + border_width
+            iw = max(allocation.width - (2 * self._frame_width) - (2 * border_width), 0)
+            ih = max(allocation.height - (2 * self._frame_width) - (2 * border_width) - 23, 0)
             i_rect.x, i_rect.y, i_rect.w, i_rect.h = ix, iy, iw, ih
             self._current_tab.item.size_allocate(i_rect)
 

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -781,9 +781,9 @@ class DockGroup(Gtk.Container):
         '''
         # Set some data so the DnD process continues
         selection_data.set(
-            type=Gdk.atom_intern(atom_name=DRAG_TARGET_ITEM_LIST.target, only_if_exists=False),
-            format=8,
-            data=bytes("{} tabs".format(len(self.dragcontext.dragged_object)), "utf-8")
+            Gdk.atom_intern(atom_name=DRAG_TARGET_ITEM_LIST.target, only_if_exists=False),
+            8,
+            bytes("{} tabs".format(len(self.dragcontext.dragged_object)), "utf-8")
         )
 
     def do_drag_data_delete(self, context):

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -511,7 +511,7 @@ class DockGroup(Gtk.Container):
         # Draw frame
         style_context.save()
         style_context.set_state(self.state)
-        style_provider.load_from_data(b"* { border-width: {}; }".format(self._frame_width))
+        style_provider.load_from_data(bytes("* { border-width: {}; }".format(self._frame_width), "utf-8"))
         Gtk.render_frame(context=style_context, cr=cr, x=0.5, y=0.5, width=a.width, height=a.height)
         style_context.restore()
 
@@ -528,7 +528,7 @@ class DockGroup(Gtk.Container):
             style_context.save()
             style_context.set_state(self._tab_state)
             style_provider.save()
-            style_provider.load_from_data(b"* { border-width: {}; }".format(self.border_width))
+            style_provider.load_from_data(bytes("* { border-width: {}; }".format(self.border_width), "utf-8"))
             Gtk.render_frame(
                 context=style_context,
                 cr=cr,
@@ -769,9 +769,11 @@ class DockGroup(Gtk.Container):
         For group movement, no special action is taken.
         '''
         # Set some data so the DnD process continues
-        selection_data.set(Gdk.atom_intern(atom_name=DRAG_TARGET_ITEM_LIST.target, only_if_exists=False),
-                           8,
-                           '%d tabs' % len(self.dragcontext.dragged_object))
+        selection_data.set(
+            type=Gdk.atom_intern(atom_name=DRAG_TARGET_ITEM_LIST.target, only_if_exists=False),
+            format=8,
+            data=bytes("{} tabs".format(len(self.dragcontext.dragged_object)), "utf-8")
+        )
 
     def do_drag_data_delete(self, context):
         '''

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -30,9 +30,9 @@ from operator import attrgetter
 from time import time
 
 import cairo
-import gobject
-import gtk
-import gtk.gdk as gdk
+from gi.repository import GObject
+from gi.repository import Gtk
+import Gtk.gdk as gdk
 
 from etkdocking import _
 from .compactbutton import CompactButton
@@ -50,11 +50,11 @@ class _DockGroupTab(object):
                  'item_title_handler',  # item title property notification signal handler id
                  'item_title_tooltip_text_handler',
                  # item title-tooltip-text property notification signal handler id
-                 'image',  # icon (gtk.Image)
-                 'label',  # title (gtk.Label)
+                 'image',  # icon (Gtk.Image)
+                 'label',  # title (Gtk.Label)
                  'button',  # close button (etk.docking.CompactButton)
-                 'menu_item',  # menu item (gtk.ImageMenuItem)
-                 'area',  # area, used for hit testing (gdk.Rectangle)
+                 'menu_item',  # menu item (Gtk.ImageMenuItem)
+                 'area',  # area, used for hit testing ()
                  'last_focused']  # timestamp set last time a tab was focused
 
     def __contains__(self, pos):
@@ -67,9 +67,9 @@ class _DockGroupTab(object):
                                                               self.area)
 
 
-class DockGroup(gtk.Container):
+class DockGroup(Gtk.Container):
     '''
-    The etk.DockGroup widget is a gtk.Container that groups its children in a
+    The etk.DockGroup widget is a Gtk.Container that groups its children in a
     tabbed interface.
 
     Tabs can be reorder by dragging them to the desired location within the
@@ -80,20 +80,20 @@ class DockGroup(gtk.Container):
     '''
     __gtype_name__ = 'EtkDockGroup'
     __gsignals__ = {'item-added':
-                        (gobject.SIGNAL_RUN_LAST,
-                         gobject.TYPE_NONE,
-                         (gobject.TYPE_OBJECT,)),
+                        (GObject.SignalFlags.RUN_LAST,
+                         None,
+                         (GObject.TYPE_OBJECT,)),
                     'item-removed':
-                        (gobject.SIGNAL_RUN_LAST,
-                         gobject.TYPE_NONE,
-                         (gobject.TYPE_OBJECT,)),
+                        (GObject.SignalFlags.RUN_LAST,
+                         None,
+                         (GObject.TYPE_OBJECT,)),
                     'item-selected':
-                        (gobject.SIGNAL_RUN_LAST,
-                         gobject.TYPE_NONE,
-                         (gobject.TYPE_OBJECT,))}
+                        (GObject.SignalFlags.RUN_LAST,
+                         None,
+                         (GObject.TYPE_OBJECT,))}
 
     def __init__(self):
-        gtk.Container.__init__(self)
+        GObject.GObject.__init__(self)
 
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))
@@ -103,15 +103,15 @@ class DockGroup(gtk.Container):
         self._frame_width = 1
         self._spacing = 3
         self._available_width = 0
-        self._decoration_area = gdk.Rectangle()
+        self._decoration_area = ()
 
         self._tabs = []
         self._visible_tabs = []
         self._current_tab = None
-        self._tab_state = gtk.STATE_SELECTED
+        self._tab_state = Gtk.StateType.SELECTED
         self.dragcontext = DockDragContext()
 
-        gtk.widget_push_composite_child()
+        Gtk.widget_push_composite_child()
         self._list_button = CompactButton('compact-list')
         self._list_button.set_tooltip_text(_('Show list'))
         self._list_button.connect('clicked', self._on_list_button_clicked)
@@ -124,11 +124,11 @@ class DockGroup(gtk.Container):
         self._max_button.set_tooltip_text(_('Maximize'))
         self._max_button.connect('clicked', self._on_max_button_clicked)
         self._max_button.set_parent(self)
-        self._tab_menu = gtk.Menu()
+        self._tab_menu = Gtk.Menu()
         self._tab_menu.attach_to_widget(self, None)
-        self._list_menu = gtk.Menu()
+        self._list_menu = Gtk.Menu()
         self._list_menu.attach_to_widget(self._list_button, None)
-        gtk.widget_pop_composite_child()
+        Gtk.widget_pop_composite_child()
 
     def __len__(self):
         return len(self._tabs)
@@ -138,21 +138,21 @@ class DockGroup(gtk.Container):
     ############################################################################
     def do_realize(self):
         # Internal housekeeping
-        self.set_flags(self.flags() | gtk.REALIZED)
-        self.window = gdk.Window(self.get_parent_window(),
+        self.set_flags(self.flags() | Gtk.REALIZED)
+        self.window = Gdk.Window(self.get_parent_window(),
                                  x=self.allocation.x,
                                  y=self.allocation.y,
                                  width=self.allocation.width,
                                  height=self.allocation.height,
-                                 window_type=gdk.WINDOW_CHILD,
-                                 wclass=gdk.INPUT_OUTPUT,
-                                 event_mask=(gdk.EXPOSURE_MASK |
-                                             gdk.POINTER_MOTION_MASK |
-                                             gdk.BUTTON_PRESS_MASK |
-                                             gdk.BUTTON_RELEASE_MASK))
+                                 window_type=Gdk.WINDOW_CHILD,
+                                 wclass=Gdk.INPUT_OUTPUT,
+                                 event_mask=(Gdk.EventMask.EXPOSURE_MASK |
+                                             Gdk.EventMask.POINTER_MOTION_MASK |
+                                             Gdk.EventMask.BUTTON_PRESS_MASK |
+                                             Gdk.EventMask.BUTTON_RELEASE_MASK))
         self.window.set_user_data(self)
         self.style.attach(self.window)
-        self.style.set_background(self.window, gtk.STATE_NORMAL)
+        self.style.set_background(self.window, Gtk.StateType.NORMAL)
 
         # Set parent window on all child widgets
         for tab in self._tabs:
@@ -168,10 +168,10 @@ class DockGroup(gtk.Container):
     def do_unrealize(self):
         self.window.set_user_data(None)
         self.window.destroy()
-        gtk.Container.do_unrealize(self)
+        Gtk.Container.do_unrealize(self)
 
     def do_map(self):
-        gtk.Container.do_map(self)
+        Gtk.Container.do_map(self)
         self._list_button.show()
         self._min_button.show()
         self._max_button.show()
@@ -182,10 +182,10 @@ class DockGroup(gtk.Container):
         self._min_button.hide()
         self._max_button.hide()
         self.window.hide()
-        gtk.Container.do_unmap(self)
+        Gtk.Container.do_unmap(self)
 
     def do_size_request(self, requisition):
-        gtk.Container.do_size_request(self, requisition)
+        Gtk.Container.do_size_request(self, requisition)
 
         # Start with a zero sized decoration area
         dw = dh = 0
@@ -242,7 +242,7 @@ class DockGroup(gtk.Container):
     def do_size_allocate(self, allocation):
         self.allocation = allocation
 
-        if self.flags() & gtk.REALIZED:
+        if self.get_realized():
             self.window.move_resize(*allocation)
 
         # Allocate space for decoration buttons
@@ -252,11 +252,11 @@ class DockGroup(gtk.Container):
         bh = max(list_h, min_h, max_h)
         by = self._frame_width + self._spacing
         self._max_button.size_allocate(
-            gdk.Rectangle(allocation.width - self._frame_width - self._spacing - max_w, by, max_w, bh))
+            (allocation.width - self._frame_width - self._spacing - max_w, by, max_w, bh))
         self._min_button.size_allocate(
-            gdk.Rectangle(allocation.width - self._frame_width - self._spacing - max_w - min_w, by, min_w, bh))
+            (allocation.width - self._frame_width - self._spacing - max_w - min_w, by, min_w, bh))
         self._list_button.size_allocate(
-            gdk.Rectangle(allocation.width - self._frame_width - self._spacing - max_w - min_w - list_w, by, list_w,
+            (allocation.width - self._frame_width - self._spacing - max_w - min_w - list_w, by, list_w,
                           bh))
 
         # Compute available tab area width
@@ -277,7 +277,7 @@ class DockGroup(gtk.Container):
                 tab.item.hide()
                 tab.image.show()
                 tab.label.show()
-            elif tab.item.flags() & gtk.VISIBLE:
+            elif tab.item.flags() & Gtk.VISIBLE:
                 tab.item.hide()
                 tab.image.hide()
                 tab.label.hide()
@@ -303,7 +303,7 @@ class DockGroup(gtk.Container):
 
             ix = cx + self._frame_width + self._spacing
             iy = old_div((tab.area.height - ih), 2) + 1
-            tab.image.size_allocate(gdk.Rectangle(ix, iy, iw, ih))
+            tab.image.size_allocate((ix, iy, iw, ih))
 
             if len(self._visible_tabs) == 1:
                 lw = tab.area.width - (self._frame_width + self._spacing + iw +
@@ -313,12 +313,12 @@ class DockGroup(gtk.Container):
 
             lx = cx + self._frame_width + self._spacing + iw + self._spacing
             ly = old_div((tab.area.height - lh), 2) + 1
-            tab.label.size_allocate(gdk.Rectangle(lx, ly, lw, lh))
+            tab.label.size_allocate((lx, ly, lw, lh))
 
             bx = (cx + self._frame_width + self._spacing + iw +
                   self._spacing + lw + self._spacing)
             by = old_div((tab.area.height - bh), 2) + 1
-            tab.button.size_allocate(gdk.Rectangle(bx, by, bw, bh))
+            tab.button.size_allocate((bx, by, bw, bh))
 
             cx += tab.area.width
 
@@ -328,7 +328,7 @@ class DockGroup(gtk.Container):
             iy = self._decoration_area.height + self.border_width
             iw = max(allocation.width - (2 * self._frame_width) - (2 * self.border_width), 0)
             ih = max(allocation.height - (2 * self._frame_width) - (2 * self.border_width) - 23, 0)
-            self._current_tab.item.size_allocate(gdk.Rectangle(ix, iy, iw, ih))
+            self._current_tab.item.size_allocate((ix, iy, iw, ih))
 
         # assert not self._current_tab or self._current_tab in self._visible_tabs
         self.queue_draw_area(0, 0, self.allocation.width, self.allocation.height)
@@ -341,7 +341,7 @@ class DockGroup(gtk.Container):
         dark = (dark.red_float, dark.green_float, dark.blue_float)
         tab_light = self.style.text_aa[self._tab_state]
         tab_light = (tab_light.red_float, tab_light.green_float, tab_light.blue_float)
-        tab_dark = HslColor(self.style.text_aa[gtk.STATE_SELECTED])
+        tab_dark = HslColor(self.style.text_aa[Gtk.StateType.SELECTED])
         tab_dark.set_l(0.9)
         tab_dark = tab_dark.get_rgb_float()
 
@@ -510,7 +510,7 @@ class DockGroup(gtk.Container):
         # current tab's child widget
         if event.window is self.window:
             # Check if we are actually starting a DnD operation
-            if event.state & gdk.BUTTON1_MASK and \
+            if event.get_state() & Gdk.ModifierType.BUTTON1_MASK and \
                     self.dragcontext.source_button == 1 and \
                     self.drag_check_threshold(int(self.dragcontext.source_x),
                                               int(self.dragcontext.source_y),
@@ -528,7 +528,7 @@ class DockGroup(gtk.Container):
                     self.dragcontext.dragged_object = [t.item for t in self._tabs]
 
                 if self.dragcontext.dragged_object:
-                    self.drag_begin([DRAG_TARGET_ITEM_LIST], gdk.ACTION_MOVE,
+                    self.drag_begin([DRAG_TARGET_ITEM_LIST], Gdk.DragAction.MOVE,
                                     self.dragcontext.source_button, event)
 
             # Update tab button visibility
@@ -548,7 +548,7 @@ class DockGroup(gtk.Container):
     ############################################################################
     def do_drag_begin(self, context):
         '''
-        :param context: the gdk.DragContext
+        :param context: the Gdk.DragContext
 
         The do_drag_begin() signal handler is executed on the drag source when
         the user initiates a drag operation. A typical reason to use this signal
@@ -563,13 +563,13 @@ class DockGroup(gtk.Container):
         # TODO: Set drag icon to be empty
         # TODO: Set drag cursor -> will most likely not (only) happen here...
         # Can be any of the following, depending on the selected drag destination:
-        #   - gdk.DIAMOND_CROSS    "stacking" a dockitem into a dockgroup
-        #   - gdk.SB_UP_ARROW      "splitting" a dockitem into a new dockgroup above the source dockgroup (needs docklayout)
-        #   - gdk.SB_DOWN_ARROW    "splitting" a dockitem into a new dockgroup below the source dockgroup (needs docklayout)
-        #   - gdk.SB_LEFT_ARROW    "splitting" a dockitem into a new dockgroup on the left of the source dockgroup (needs docklayout)
-        #   - gdk.SB_RIGHT_ARROW   "splitting" a dockitem into a new dockgroup on the right of the source dockgroup (needs docklayout)
+        #   - Gdk.DIAMOND_CROSS    "stacking" a dockitem into a dockgroup
+        #   - Gdk.SB_UP_ARROW      "splitting" a dockitem into a new dockgroup above the source dockgroup (needs docklayout)
+        #   - Gdk.SB_DOWN_ARROW    "splitting" a dockitem into a new dockgroup below the source dockgroup (needs docklayout)
+        #   - Gdk.SB_LEFT_ARROW    "splitting" a dockitem into a new dockgroup on the left of the source dockgroup (needs docklayout)
+        #   - Gdk.SB_RIGHT_ARROW   "splitting" a dockitem into a new dockgroup on the right of the source dockgroup (needs docklayout)
 
-        # dnd_window = gtk.Window(gtk.WINDOW_POPUP)
+        # dnd_window = Gtk.Window(Gtk.WindowType.POPUP)
         # dnd_window.set_screen(self.get_screen())
         # dnd_window.add(tab.item)
         # dnd_window.set_size_request(tab.item.allocation.width,
@@ -580,14 +580,14 @@ class DockGroup(gtk.Container):
 
     def do_drag_data_get(self, context, selection_data, info, timestamp):
         '''
-        :param context: the gdk.DragContext
-        :param selection_data: a gtk.SelectionData object
+        :param context: the Gdk.DragContext
+        :param selection_data: a Gtk.SelectionData object
         :param info: an integer ID for the drag
         :param timestamp: the time of the drag event
 
         The do_drag_data_get() signal handler is executed when a drag operation
         completes that copies data or when a drag drop occurs using the
-        gdk.DRAG_PROTO_ROOTWIN protocol. The drag source executes this
+        Gdk.DRAG_PROTO_ROOTWIN protocol. The drag source executes this
         handler when the drag destination requests the data using the
         drag_get_data() method. This handler needs to fill selection_data
         with the data in the format specified by the target associated with
@@ -599,13 +599,13 @@ class DockGroup(gtk.Container):
         For group movement, no special action is taken.
         '''
         # Set some data so the DnD process continues
-        selection_data.set(gdk.atom_intern(DRAG_TARGET_ITEM_LIST[0]),
+        selection_data.set(Gdk.atom_intern(DRAG_TARGET_ITEM_LIST[0]),
                            8,
                            '%d tabs' % len(self.dragcontext.dragged_object))
 
     def do_drag_data_delete(self, context):
         '''
-        :param context: the gdk.DragContext
+        :param context: the Gdk.DragContext
 
         The do_drag_data_delete() signal handler is executed when the drag
         completes a move operation and requires the source data to be deleted.
@@ -619,7 +619,7 @@ class DockGroup(gtk.Container):
 
     def do_drag_end(self, context):
         '''
-        :param context: the gdk.DragContext
+        :param context: the Gdk.DragContext
 
         The do_drag_end() signal handler is executed when the drag operation is
         completed. A typical reason to use this signal handler is to undo things
@@ -771,7 +771,7 @@ class DockGroup(gtk.Container):
 
     def set_tab_state(self, tab_state):
         '''
-        Define the tab state. Normally that will be ``gtk.STATE_SELECTED``, but a
+        Define the tab state. Normally that will be ``Gtk.StateType.SELECTED``, but a
         different state can be set if required.
         '''
         self._tab_state = tab_state
@@ -848,13 +848,13 @@ class DockGroup(gtk.Container):
             position = len(self)
 
         # Create composite children for tab
-        gtk.widget_push_composite_child()
+        Gtk.widget_push_composite_child()
         tab = _DockGroupTab()
         tab.image = item.get_image()
-        tab.label = gtk.Label()
+        tab.label = Gtk.Label()
         tab.button = CompactButton(has_frame=False)
-        tab.menu_item = gtk.ImageMenuItem()
-        gtk.widget_pop_composite_child()
+        tab.menu_item = Gtk.ImageMenuItem()
+        Gtk.widget_pop_composite_child()
 
         # Configure child widgets for tab
         tab.item = item
@@ -873,10 +873,10 @@ class DockGroup(gtk.Container):
         tab.menu_item.set_label(item.get_title())
         tab.menu_item.connect('activate', self._on_list_menu_item_activated, tab)
         self._list_menu.append(tab.menu_item)
-        tab.area = gdk.Rectangle()
+        tab.area = ()
         tab.last_focused = time()
 
-        if self.flags() & gtk.REALIZED:
+        if self.get_realized():
             tab.item.set_parent_window(self.window)
             tab.image.set_parent_window(self.window)
             tab.label.set_parent_window(self.window)
@@ -1054,11 +1054,11 @@ class DockGroup(gtk.Container):
         self.queue_resize()
 
         if tab is self._current_tab:
-            tab.menu_item.child.set_use_markup(True)
-            tab.menu_item.child.set_markup('<b>%s</b>' % tab.item.get_title())
+            tab.menu_item.get_child().set_use_markup(True)
+            tab.menu_item.get_child().set_markup('<b>%s</b>' % tab.item.get_title())
         else:
-            tab.menu_item.child.set_use_markup(False)
-            tab.menu_item.child.set_markup(tab.item.get_title())
+            tab.menu_item.get_child().set_use_markup(False)
+            tab.menu_item.get_child().set_markup(tab.item.get_title())
 
     def _on_item_title_changed(self, item, pspec, tab):
         self._item_title_changed(tab)

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -811,9 +811,12 @@ class DockGroup(Gtk.Container):
             # If the current item's tab is the only visible tab,
             # we need to recalculate its tab.area.width
             if len(self._visible_tabs) == 1:
-                (iw, ih) = self._current_tab.image.get_child_requisition()
-                (lw, lh) = self._current_tab.label.get_child_requisition()
-                (bh, bw) = self._current_tab.button.get_child_requisition()
+                min_size, natural_size = self._current_tab.image.get_preferred_size()
+                iw, ih = natural_size.width, natural_size.height
+                min_size, natural_size = self._current_tab.label.get_preferred_size()
+                lw, lh = natural_size.width, natural_size.height
+                min_size, natural_size = self._current_tab.button.get_preferred_size()
+                bh, bw = natural_size.width, natural_size.height
 
                 normal = (self._frame_width + self._spacing + iw +
                           self._spacing + lw + self._spacing + bw +

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -146,6 +146,17 @@ class DockGroup(Gtk.Container):
         return len(self._tabs)
 
     ############################################################################
+    # GObject
+    ############################################################################
+    def do_get_property(self, pspec):
+        if pspec.name == 'weight':
+            return self.get_weight()
+
+    def do_set_property(self, pspec, value):
+        if pspec.name == 'weight':
+            self.set_weight(value)
+
+    ############################################################################
     # GtkWidget
     ############################################################################
     def do_realize(self):

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -654,7 +654,7 @@ class DockGroup(Gtk.Container):
         For group movement, no special action is taken.
         '''
         # Set some data so the DnD process continues
-        selection_data.set(Gdk.atom_intern(DRAG_TARGET_ITEM_LIST[0]),
+        selection_data.set(Gdk.atom_intern(DRAG_TARGET_ITEM_LIST.target),
                            8,
                            '%d tabs' % len(self.dragcontext.dragged_object))
 

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -21,9 +21,9 @@
 
 from __future__ import absolute_import
 from __future__ import division
-from builtins import object
+
 from builtins import hex
-from past.utils import old_div
+from builtins import object
 from logging import getLogger
 from math import pi
 from operator import attrgetter
@@ -31,9 +31,12 @@ from time import time
 
 import cairo
 import gi
+from past.utils import old_div
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk, GObject
+from gi.repository import Gdk
+from gi.repository import GObject
+from gi.repository import Gtk
 
 from . import _
 from .compactbutton import CompactButton
@@ -111,7 +114,7 @@ class DockGroup(Gtk.Container):
         self._current_tab = None
         self._tab_state = Gtk.StateType.SELECTED
         self.dragcontext = DockDragContext()
-
+        # TODO: Deprecated in Gtk 3.10, composite children are handled by Gtk.WidgetClass.set_template()
         Gtk.Widget.push_composite_child()
         self._list_button = CompactButton('compact-list')
         self._list_button.set_tooltip_text(_('Show list'))
@@ -924,6 +927,7 @@ class DockGroup(Gtk.Container):
         tab.image = item.get_image()
         tab.label = Gtk.Label()
         tab.button = CompactButton(has_frame=False)
+        # TODO: Gtk.ImageMenuItem() has been deprecated in Gtk 3.10 for Gtk.MenuItem()
         tab.menu_item = Gtk.ImageMenuItem()
         Gtk.Widget.pop_composite_child()
 

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -138,22 +138,29 @@ class DockGroup(Gtk.Container):
     # GtkWidget
     ############################################################################
     def do_realize(self):
-        # Internal housekeeping
-        self.set_flags(self.flags() | Gtk.REALIZED)
-        self.window = Gdk.Window(self.get_parent_window(),
-                                 x=self.allocation.x,
-                                 y=self.allocation.y,
-                                 width=self.allocation.width,
-                                 height=self.allocation.height,
-                                 window_type=Gdk.WINDOW_CHILD,
-                                 wclass=Gdk.INPUT_OUTPUT,
-                                 event_mask=(Gdk.EventMask.EXPOSURE_MASK |
-                                             Gdk.EventMask.POINTER_MOTION_MASK |
-                                             Gdk.EventMask.BUTTON_PRESS_MASK |
-                                             Gdk.EventMask.BUTTON_RELEASE_MASK))
+        allocation = self.get_allocation()
+        attr = Gdk.WindowAttr()
+        attr.x = allocation.x
+        attr.y = allocation.y
+        attr.width = allocation.width
+        attr.height = allocation.height
+        attr.window_type = Gdk.WindowType.CHILD
+        attr.wclass = Gdk.WindowWindowClass.INPUT_OUTPUT
+        attr.event_mask = (
+            Gdk.EventMask.EXPOSURE_MASK
+            | Gdk.EventMask.POINTER_MOTION_MASK
+            | Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.BUTTON_RELEASE_MASK
+        )
+        attr_mask = (
+            Gdk.WindowAttributesType.X
+            | Gdk.WindowAttributesType.Y
+            | Gdk.WindowAttributesType.WMCLASS
+        )
+        self.window = Gdk.Window(self.get_parent_window(), attr, attr_mask)
         self.window.set_user_data(self)
-        self.style.attach(self.window)
-        self.style.set_background(self.window, Gtk.StateType.NORMAL)
+        self.set_window(self.window)
+        self.set_realized(True)
 
         # Set parent window on all child widgets
         for tab in self._tabs:

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -149,6 +149,7 @@ class DockGroup(Gtk.Container):
     # GtkWidget
     ############################################################################
     def do_realize(self):
+        self.get_realized()
         allocation = self.get_allocation()
         attr = Gdk.WindowAttr()
         attr.x = allocation.x
@@ -170,10 +171,8 @@ class DockGroup(Gtk.Container):
         )
         self.window = Gdk.Window(self.get_parent_window(), attr, attr_mask)
         self.window.set_user_data(self)
-        # self.window.style = self.window.get_style_context()
-        # self.window.style.set_state(Gtk.StateFlags.NORMAL)
-        self.set_window(self.window)
-        self.set_realized(True)
+        # TODO: do we care about attaching style information?
+        # self.style_attach()
 
         # Set parent window on all child widgets
         for tab in self._tabs:
@@ -187,23 +186,23 @@ class DockGroup(Gtk.Container):
         self._max_button.set_parent_window(self.window)
 
     def do_unrealize(self):
-        self.set_realized(False)
         self.window.set_user_data(None)
         self.window.destroy()
+        Gtk.Container.do_unrealize(self)
 
     def do_map(self):
+        Gtk.Container.do_map(self)
         self._list_button.show()
         self._min_button.show()
         self._max_button.show()
         self.window.show()
-        self.set_mapped(True)
 
     def do_unmap(self):
-        self.set_mapped(False)
         self._list_button.hide()
         self._min_button.hide()
         self._max_button.hide()
         self.window.hide()
+        Gtk.Container.do_unmap(self)
 
     def do_size_request(self, requisition):
 

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -849,13 +849,13 @@ class DockGroup(Gtk.Container):
             position = len(self)
 
         # Create composite children for tab
-        Gtk.widget_push_composite_child()
+        Gtk.Widget.push_composite_child()
         tab = _DockGroupTab()
         tab.image = item.get_image()
         tab.label = Gtk.Label()
         tab.button = CompactButton(has_frame=False)
         tab.menu_item = Gtk.ImageMenuItem()
-        Gtk.widget_pop_composite_child()
+        Gtk.Widget.pop_composite_child()
 
         # Configure child widgets for tab
         tab.item = item

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -83,6 +83,14 @@ class DockGroup(Gtk.Container):
     etk.DockGroup.
     '''
     __gtype_name__ = 'EtkDockGroup'
+    __gproperties__ = {'weight':
+                        (GObject.TYPE_FLOAT,
+                         'item weight',
+                         'item weight',
+                         0,  # min
+                         1,  # max
+                         .2,  # default
+                         GObject.ParamFlags.READWRITE)}
     __gsignals__ = {'item-added':
                         (GObject.SignalFlags.RUN_LAST,
                          None,

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -97,7 +97,7 @@ class DockGroup(Gtk.Container):
                          (GObject.TYPE_OBJECT,))}
 
     def __init__(self):
-        GObject.GObject.__init__(self)
+        Gtk.Container.__init__(self)
 
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -694,21 +694,29 @@ class DockGroup(Gtk.Container):
     ############################################################################
     # GtkContainer
     ############################################################################
-    def do_forall(self, internals, callback, data):
-        # Internal widgets
-        if internals:
-            for tab in self._tabs:
-                callback(tab.image, data)
-                callback(tab.label, data)
-                callback(tab.button, data)
+    def do_forall(self, include_internals, callback, *callback_data):
+        """Invokes the given callback on each tab, with the given data.
 
-            callback(self._list_button, data)
-            callback(self._min_button, data)
-            callback(self._max_button, data)
+        @param include_internals Whether to run on internal children as well, as
+                                 boolean. Ignored, as there are no internal
+                                 children.
+        @param callback The callback to call on each child, as Gtk.Callback
+        @param callback_data The parameters to pass to the callback, as object
+                             or None
+        """
+        if include_internals:
+            for tab in self._tabs:
+                callback(tab.image, *callback_data)
+                callback(tab.label, *callback_data)
+                callback(tab.button, *callback_data)
+
+            callback(self._list_button, *callback_data)
+            callback(self._min_button, *callback_data)
+            callback(self._max_button, *callback_data)
 
         # Docked items
         for tab in self._tabs:
-            callback(tab.item, data)
+            callback(tab.item)
 
     def do_add(self, widget):
         if widget not in (tab.item for tab in self._tabs):

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -928,7 +928,7 @@ class DockGroup(Gtk.Container):
         tab.menu_item.set_label(item.get_title())
         tab.menu_item.connect('activate', self._on_list_menu_item_activated, tab)
         self._list_menu.append(tab.menu_item)
-        tab.area = ()
+        tab.area = Gdk.Rectangle()
         tab.last_focused = time()
 
         if self.get_realized():

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -517,7 +517,7 @@ class DockGroup(Gtk.Container):
         a = self.allocation
 
         # Draw background
-        Gtk.render_backgound(context=style_context, cr=cr, x=0.5, y=0.5, width=a.width, height=a.height)
+        Gtk.render_background(context=style_context, cr=cr, x=0.5, y=0.5, width=a.width, height=a.height)
 
         # Draw frame
         style_context.save()

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -834,8 +834,11 @@ class DockGroup(Gtk.Container):
         '''
         self._tab_state = tab_state
 
-        if self.allocation:
-            self.queue_draw_area(0, 0, self.allocation.width, self.allocation.height)
+        allocation = self.get_allocation()
+        if allocation:
+            self.queue_draw_area(
+                0, 0, allocation.width, allocation.height
+            )
 
     def get_tab_state(self):
         '''

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -47,9 +47,9 @@ from .util import rect_contains
 
 
 class _DockGroupTab(object):
-    '''
-    Convenience class storing information about a tab.
-    '''
+    """ Convenience class storing information about a tab.
+
+    """
     __slots__ = ['item',  # DockItem associated with this tab
                  'item_title_handler',  # item title property notification signal handler id
                  'item_title_tooltip_text_handler',
@@ -72,25 +72,26 @@ class _DockGroupTab(object):
 
 
 class DockGroup(Gtk.Container):
-    '''
-    The etk.DockGroup widget is a Gtk.Container that groups its children in a
+    """
+    The DockGroup widget is a Gtk.Container that groups its children in a
     tabbed interface.
 
     Tabs can be reorder by dragging them to the desired location within the
     same or another etk.DockGroup having the same group-id. You can also drag
     a complete etk.DockGroup onto another etk.DockGroup having the same group-id
     to merge all etk.DockItems from the source into the destination
-    etk.DockGroup.
-    '''
+    DockGroup.
+
+    """
     __gtype_name__ = 'EtkDockGroup'
     __gproperties__ = {'weight':
-                        (GObject.TYPE_FLOAT,
-                         'item weight',
-                         'item weight',
-                         0,  # min
-                         1,  # max
-                         .2,  # default
-                         GObject.ParamFlags.READWRITE)}
+                           (GObject.TYPE_FLOAT,
+                            'item weight',
+                            'item weight',
+                            0,  # min
+                            1,  # max
+                            .2,  # default
+                            GObject.ParamFlags.READWRITE)}
     __gsignals__ = {'item-added':
                         (GObject.SignalFlags.RUN_LAST,
                          None,
@@ -110,7 +111,7 @@ class DockGroup(Gtk.Container):
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))
 
-        # Internal housekeeping
+        self.weight = None
         self.set_border_width(2)
         self._frame_width = 1
         self._spacing = 3
@@ -150,18 +151,36 @@ class DockGroup(Gtk.Container):
     # GObject
     ############################################################################
     def do_get_property(self, pspec):
+        """Gets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): A property of the CompactButton.
+
+        Returns:
+            The parameter value.
+
+        """
         if pspec.name == 'weight':
             return self.get_weight()
 
     def do_set_property(self, pspec, value):
+        """Sets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): The property of the CompactButton to set.
+            value: the value to set.
+
+        """
         if pspec.name == 'weight':
             self.set_weight(value)
 
     ############################################################################
-    # GtkWidget
+    # Gtk.Widget
     ############################################################################
     def do_realize(self):
-        self.set_realized(True)
+        """Creates the Gdk window resources for the DockGroup.
+
+        """
         allocation = self.get_allocation()
         attr = Gdk.WindowAttr()
         attr.x = allocation.x
@@ -171,15 +190,15 @@ class DockGroup(Gtk.Container):
         attr.window_type = Gdk.WindowType.CHILD
         attr.wclass = Gdk.WindowWindowClass.INPUT_OUTPUT
         attr.event_mask = (
-            Gdk.EventMask.EXPOSURE_MASK
-            | Gdk.EventMask.POINTER_MOTION_MASK
-            | Gdk.EventMask.BUTTON_PRESS_MASK
-            | Gdk.EventMask.BUTTON_RELEASE_MASK
+                Gdk.EventMask.EXPOSURE_MASK
+                | Gdk.EventMask.POINTER_MOTION_MASK
+                | Gdk.EventMask.BUTTON_PRESS_MASK
+                | Gdk.EventMask.BUTTON_RELEASE_MASK
         )
         attr_mask = (
-            Gdk.WindowAttributesType.X
-            | Gdk.WindowAttributesType.Y
-            | Gdk.WindowAttributesType.WMCLASS
+                Gdk.WindowAttributesType.X
+                | Gdk.WindowAttributesType.Y
+                | Gdk.WindowAttributesType.WMCLASS
         )
         self.window = Gdk.Window(self.get_parent_window(), attr, attr_mask)
         self.window.set_user_data(self)
@@ -197,38 +216,62 @@ class DockGroup(Gtk.Container):
         self._min_button.set_parent_window(self.window)
         self._max_button.set_parent_window(self.window)
 
+        self.set_realized(True)
+
     def do_unrealize(self):
+        """Clears the Gdk window resources for the DockGroup.
+
+        """
+        self.set_realized(False)
         self.window.set_user_data(None)
         self.window.destroy()
-        Gtk.Container.do_unrealize(self)
 
     def do_map(self):
-        Gtk.Container.do_map(self)
+        """Causes the DockGroup to be mapped if it isn’t already.
+
+        """
+        # Gtk.Widget.do_map(self)
+        self.show_all()
         self._list_button.show()
         self._min_button.show()
         self._max_button.show()
         self.window.show()
+        self.set_mapped(True)
 
     def do_unmap(self):
+        """Causes the DockGroup to be unmapped if it is mapped.
+
+        """
+        self.set_mapped(False)
         self._list_button.hide()
         self._min_button.hide()
         self._max_button.hide()
         self.window.hide()
-        Gtk.Container.do_unmap(self)
 
     def do_get_request_mode(self):
-        """Returns whether the container prefers a height-for-width or a
+        """Returns the preferred container layout.
+
+        Returns whether the container prefers a height-for-width or a
         width-for-height layout. DockGroup doesn't trade width for height or
         height for width so we return CONSTANT_SIZE.
+
+        Returns:
+            Gtk.SizeRequestMode: the constant size request mode.
+
         """
         return Gtk.SizeRequestMode.CONSTANT_SIZE
 
     def do_get_preferred_height(self):
-        """Calculates the container's initial minimum and natural height. While
-        this call is specific to width-for-height requests (that we requested
+        """Calculates the container's initial minimum and natural height.
+
+        While this call is specific to width-for-height requests (that we requested
         not to get) we cannot be certain that our wishes are granted, so
         we must implement this method as well. Returns the the decoration area
         height.
+
+        Returns:
+             int: minimum height, natural height.
+
         """
         # Start with a zero sized decoration area height
         dh_min = dh_nat = 0
@@ -262,9 +305,9 @@ class DockGroup(Gtk.Container):
         max_button_min, max_button_nat = self._max_button.get_preferred_height()
 
         dh_min = max(dh_min,
-                 (self._spacing + list_button_min + self._spacing),
-                 (self._spacing + min_button_min + self._spacing),
-                 (self._spacing + max_button_min + self._spacing))
+                     (self._spacing + list_button_min + self._spacing),
+                     (self._spacing + min_button_min + self._spacing),
+                     (self._spacing + max_button_min + self._spacing))
 
         dh_nat = max(dh_nat,
                      (self._spacing + list_button_nat + self._spacing),
@@ -289,11 +332,16 @@ class DockGroup(Gtk.Container):
         return minimum_height, natural_height
 
     def do_get_preferred_width(self):
-        """Calculates the container's initial minimum and natural width. While
-        this call is specific to width-for-height requests (that we requested
-        not to get) we cannot be certain that our wishes are granted, so
-        we must implement this method as well. Returns the the decoration area
+        """Calculates the container's initial minimum and natural width.
+
+        While this call is specific to width-for-height requests (that we
+        requested not to get) we cannot be certain that our wishes are granted,
+        so we must implement this method as well. Returns the decoration area
         width.
+
+        Returns:
+            int: minimum width, natural width
+
         """
         # Start with a zero sized decoration width
         dw_min = dw_nat = 0
@@ -346,35 +394,52 @@ class DockGroup(Gtk.Container):
         return minimum_width, natural_width
 
     def do_get_preferred_height_for_width(self, width):
-        """Returns this container's minimum and natural height if it would be
-        given the specified width. While this call is specific to
-        height-for-width requests (that we requested not to get) we cannot be
-        certain that our wishes are granted, so we must implement this method
-        as well. Since we really want to be the same size always, we simply
-        return do_get_preferred_height.
+        """If given width, returns the minimum and natural height.
 
-        @param width The given width, as int. Ignored.
+        Returns the container's minimum and natural height if given the
+        specified width. While this call is specific to height-for-width
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_height.
+
+        Args:
+            width (int): The given width. Ignored.
+
+        Returns:
+            int: minimum height, natural height
+
         """
         return self.do_get_preferred_height()
 
     def do_get_preferred_width_for_height(self, height):
-        """Returns this container's minimum and natural width if it would be
-        given the specified height. While this call is specific to
-        width-for-height requests (that we requested not to get) we cannot be
-        certain that our wishes are granted, so we must implement this method
-        as well. Since we really want to be the same size always, we simply
-        return do_get_preferred_width.
+        """If given height, returns the minimum and natural width.
 
-        @param height The given height, as int. Ignored.
+        Returns the container's minimum and natural width if given the
+        specified height. While this call is specific to width-for-height
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_width.
+
+        Args:
+            height (int): The given height. Ignored.
+
+        Returns:
+            int: minimum width, natural width.
+
         """
         return self.do_get_preferred_width()
 
     def do_size_allocate(self, allocation):
-        """Assigns a size and position to the child widgets. Children may adjust
-        the given allocation in the adjust_size_allocation virtual method.
+        """Assigns a size and position to the child widgets.
 
-        @param allocation The position and size allocated to this container, as
-        Gdk.Rectangle
+        Children may adjust the given allocation in the adjust_size_allocation
+        virtual method.
+
+        Args:
+            allocation (Gdk.Rectangle): Position and size allocated.
+
         """
         self.allocation = allocation
 
@@ -401,7 +466,7 @@ class DockGroup(Gtk.Container):
 
         minb_rect = Gdk.Rectangle()
         minb_rect.height = (
-            allocation.width - self._frame_width - self._spacing - max_w - min_w
+                allocation.width - self._frame_width - self._spacing - max_w - min_w
         )
         minb_rect.width = by
         minb_rect.x = min_w
@@ -410,12 +475,12 @@ class DockGroup(Gtk.Container):
 
         listb_rect = Gdk.Rectangle()
         listb_rect.x = (
-            allocation.width
-            - self._frame_width
-            - self._spacing
-            - max_w
-            - min_w
-            - list_w
+                allocation.width
+                - self._frame_width
+                - self._spacing
+                - max_w
+                - min_w
+                - list_w
         )
         listb_rect.y = by
         listb_rect.width = list_w
@@ -424,7 +489,7 @@ class DockGroup(Gtk.Container):
 
         # Compute available tab area width
         self._available_width = (
-                    allocation.width - self._frame_width - self._spacing - max_w - min_w - list_w - self._spacing)
+                allocation.width - self._frame_width - self._spacing - max_w - min_w - list_w - self._spacing)
 
         # Update visible tabs
         self._update_visible_tabs()
@@ -511,6 +576,16 @@ class DockGroup(Gtk.Container):
         self.queue_draw_area(0, 0, self.allocation.width, self.allocation.height)
 
     def do_draw(self, cr):
+        """Draws the container to the given Cairo context.
+
+        The top left corner of the widget will be drawn to the currently set
+        origin point of the context. The container needs to propagate the draw
+        signal to its children.
+
+        Args:
+            cr (cairo.Context): The Cairo context to draw into
+
+        """
         style_provider = Gtk.CssProvider()
         style_context = self.get_style_context()
         style_context.add_provider(style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
@@ -619,19 +694,21 @@ class DockGroup(Gtk.Container):
         self.propagate_draw(self._max_button, cr)
 
     def do_button_press_event(self, event):
-        '''
-        :param event: the event that triggered the signal
-        :returns: True to stop other handlers from being invoked for the event.
-                  False to propagate the event further.
+        """Called when a pointer button is pressed.
 
-        The do_button_press_event() signal handler is executed when a mouse
-        button is pressed.
-        '''
+        Sets the drag context source position and button equal to event if the
+        event window is the DockGroup window and the button. We might start a
+        DnD operation, or we could simply be starting a click on a tab. Store
+        information from this event in self.dragcontext and decide in
+        do_motion_notify_event if we're actually starting a DnD operation.
 
-        # We might start a DnD operation, or we could simply be starting
-        # a click on a tab. Store information from this event in self.dragcontext
-        # and decide in do_motion_notify_event if we're actually starting a
-        # dnd operation.
+        Args:
+            event (Gdk.EventButton): The event that triggered the signal
+
+        Returns:
+            bool: True to stop other handlers from being invoked for the event
+
+        """
         if event.window is self.window and event.button == 1:
             self.dragcontext.source_x = event.x
             self.dragcontext.source_y = event.y
@@ -640,15 +717,20 @@ class DockGroup(Gtk.Container):
         return True
 
     def do_button_release_event(self, event):
-        '''
-        :param event: the event that triggered the signal
-        :returns: True to stop other handlers from being invoked for the event.
-                  False to propagate the event further.
+        """Called when a pointer button is released.
 
-        The do_button_release_event() signal handler is executed when a mouse
-        button is released.
-        '''
+        On pointer button release, check if the user clicked on a tab, or right
+        clicked to get a context menu. A special tab context menu is not
+        currently implemented for right clicks on a tab, but this could be a
+        potential enhancement in the future.
 
+        Args:
+            event (Gdk.EventButton): The event that triggered the signal
+
+        Returns:
+            bool: True to stop other handlers from being invoked for the event
+
+        """
         # Did we click a tab?
         clicked_tab = self.get_tab_at_pos(event.x, event.y)
 
@@ -675,15 +757,19 @@ class DockGroup(Gtk.Container):
         return True
 
     def do_motion_notify_event(self, event):
-        '''
-        :param event: the event that triggered the signal
-        :returns: True to stop other handlers from being invoked for the event.
-                  False to propagate the event further.
+        """Called when the pointer moves over the DockGroup.
 
-        The do_motion-notify-event() signal handler is executed when the mouse
-        pointer moves while over this widget.
-        '''
+        When the motion notify event happens over a DockGroup, check if a DnD
+        operation is in progress, and if so check if the user is dragging tabs
+        in the DockGroup.
 
+        Args:
+            event (Gdk.EventMotion): The event that triggered the signal
+
+        Returns:
+            bool: True to stop other handlers from being invoked for the event
+
+        """
         # Reset tooltip text
         self.set_tooltip_text(None)
 
@@ -691,7 +777,7 @@ class DockGroup(Gtk.Container):
         # current tab's child widget
         if event.window is self.window:
             # Check if we are actually starting a DnD operation
-            if event.get_state() & Gdk.ModifierType.BUTTON1_MASK and \
+            if event.state & Gdk.ModifierType.BUTTON1_MASK and \
                     self.dragcontext.source_button == 1 and \
                     self.drag_check_threshold(int(self.dragcontext.source_x),
                                               int(self.dragcontext.source_y),
@@ -725,18 +811,20 @@ class DockGroup(Gtk.Container):
         return True
 
     ############################################################################
-    # GtkWidget drag source
+    # Gtk.Widget Gdk.DragContext Operations
     ############################################################################
     def do_drag_begin(self, context):
-        '''
-        :param context: the Gdk.DragContext
+        """Called on the drag source when the user initiates a drag operation.
 
-        The do_drag_begin() signal handler is executed on the drag source when
-        the user initiates a drag operation. A typical reason to use this signal
-        handler is to set up a custom drag icon with the drag_source_set_icon()
-        method.
-        '''
-        # Free the item for transport.
+        A typical reason to use this signal handler is to set up a custom drag
+        icon with the drag_source_set_icon() method. We are currently using it
+        to remove dragged items from the DockGroup.
+
+        Args:
+            context (Gdk.DragContext): The drag context
+
+        """
+        # Free the item for transport
         for item in self.dragcontext.dragged_object:
             self._dragged_tab_index = [t.item for t in self._tabs].index(item)
             self.remove_item(self._dragged_tab_index)
@@ -759,27 +847,26 @@ class DockGroup(Gtk.Container):
         # context.set_icon_widget(dnd_window, -2, -2)
         # context.set_icon_pixmap(tab.image.get_pixmap(), -2, -2)
 
-    def do_drag_data_get(self, context, selection_data, info, timestamp):
-        '''
-        :param context: the Gdk.DragContext
-        :param selection_data: a Gtk.SelectionData object
-        :param info: an integer ID for the drag
-        :param timestamp: the time of the drag event
+    def do_drag_data_get(self, context, selection_data, info, time):
+        """Called when a drag operation completes with data.
 
-        The do_drag_data_get() signal handler is executed when a drag operation
-        completes that copies data or when a drag drop occurs using the
-        Gdk.DRAG_PROTO_ROOTWIN protocol. The drag source executes this
-        handler when the drag destination requests the data using the
-        drag_get_data() method. This handler needs to fill selection_data
-        with the data in the format specified by the target associated with
-        info.
+        Gets drag data from a drag operation that completes that copies data or
+        when a drag drop occurs using the Gdk.DRAG_PROTO_ROOTWIN protocol. The
+        drag source executes this handler when the drag destination requests
+        the data using the drag_get_data() method. This handler needs to fill
+        selection_data with the data in the format specified by the target
+        associated with info. For tab movement, here the tab is removed from
+        the group. If the drop fails, the tab is restored in do_drag_failed().
+        For group movement, no special action is taken. This method sets some
+        selection_data so that the drag operation continues.
 
-        For tab movement, here the tab is removed from the group. If the
-        drop fails, the tab is restored in do_drag_failed().
+        Args:
+            context (Gdk.DragContext): The drag context
+            selection_data (Gtk.SelectionData): The selection data for the drag
+            info (int): The ID for the drag
+            time (int): The timestamp of the drag event
 
-        For group movement, no special action is taken.
-        '''
-        # Set some data so the DnD process continues
+        """
         selection_data.set(
             Gdk.atom_intern(atom_name=DRAG_TARGET_ITEM_LIST.target, only_if_exists=False),
             8,
@@ -787,30 +874,34 @@ class DockGroup(Gtk.Container):
         )
 
     def do_drag_data_delete(self, context):
-        '''
-        :param context: the Gdk.DragContext
+        """Called when the drag completes and data needs to be deleted.
 
-        The do_drag_data_delete() signal handler is executed when the drag
-        completes a move operation and requires the source data to be deleted.
-        The handler is responsible for deleting the data that has been dropped.
+        This is executed when the drag completes a move operation and requires
+        the source data to be deleted. The handler is responsible for deleting
+        the data that has been dropped. For groups, the group is deleted, for
+        tabs the group is destroyed of there are no more tabs left (see
+        do_drag_data_get()). DockLayout handles this so this method just
+        executes a pass.
 
-        For groups, the group is deleted, for tabs the group is destroyed
-        of there are no more tabs left (see do_drag_data_get()).
-        '''
-        # Let this be handled by the DockLayout
+        Args:
+            context (Gdk.DragContext): The drag context
+
+        """
         pass
 
     def do_drag_end(self, context):
-        '''
-        :param context: the Gdk.DragContext
+        """Called when the drag operation is completed.
 
-        The do_drag_end() signal handler is executed when the drag operation is
-        completed. A typical reason to use this signal handler is to undo things
-        done in the do_drag_begin() handler.
+        This is executed when the drag operation is completed. A typical reason
+        to use this signal handler is to undo things done in the
+        do_drag_begin() handler. In this case, items detached on drag-begin are
+        connected to the group again, if not attached to some other widget
+        already.
 
-        In this case, items distached on drag-begin are connected to the group
-        again, if not attached to some other widget already.
-        '''
+        Args:
+            context (Gdk.DragContext): The drag context
+
+        """
         if self.dragcontext.dragging and self.dragcontext.dragged_object:
             for item in self.dragcontext.dragged_object:
                 if not item.get_parent():
@@ -820,17 +911,17 @@ class DockGroup(Gtk.Container):
         self.queue_resize()
 
     ############################################################################
-    # GtkContainer
+    # Gtk.Container
     ############################################################################
     def do_forall(self, include_internals, callback, *callback_data):
         """Invokes the given callback on each tab, with the given data.
 
-        @param include_internals Whether to run on internal children as well, as
-                                 boolean. Ignored, as there are no internal
-                                 children.
-        @param callback The callback to call on each child, as Gtk.Callback
-        @param callback_data The parameters to pass to the callback, as object
-                             or None
+        Args:
+            include_internals (bool): Run on internal children
+            callback (Gtk.Callback): The callback to call on each child
+            callback_data (object or None): The parameters to pass to the
+                callback
+
         """
         if include_internals:
             for tab in self._tabs:
@@ -844,16 +935,68 @@ class DockGroup(Gtk.Container):
 
         # Docked items
         for tab in self._tabs:
-            callback(tab.item)
+            callback(tab.item, *callback_data)
 
     def do_add(self, widget):
+        """Called when the given widget is added to the DockGroup.
+
+        Args:
+            widget (Gtk.Widget): The widget to add
+
+        """
         if widget not in (tab.item for tab in self._tabs):
             self._insert_item(widget)
 
     def do_remove(self, widget):
+        """Called when the given widget is removed from the DockGroup.
+
+        Args:
+            widget (Gtk.Widget): The widget to remove
+
+        """
         self._remove_item(widget)
 
+    def do_child_type(self):
+        """Indicates that this container accepts any Gtk.Widget.
+
+        """
+        return Gtk.Widget.get_type()
+
+    ############################################################################
+    # EtkDockGroup
+    ############################################################################
+    items = property(lambda s: [t.item for t in s._tabs])
+
+    visible_items = property(lambda s: [t.item for t in s._visible_tabs])
+
+    def __contains__(self, item):
+        return item in self.items
+
+    def get_weight(self):
+        """Get the weight of the DockPaned.
+
+        Returns:
+            float: The weight
+
+        """
+        return self.weight
+
+    def set_weight(self, weight):
+        """Set the weight of the DockPaned.
+
+        Args:
+            weight (float): The weight
+
+        """
+        self.weight = weight
+
     def _remove_item(self, child):
+        """Removes an item from the DockGroup.
+
+        Args:
+            child (Gtk.Widget): The child widget to remove from the DockGroup
+
+        """
         assert child in (tab.item for tab in self._tabs)
 
         item_num = self.item_num(child)
@@ -887,20 +1030,14 @@ class DockGroup(Gtk.Container):
         self.set_current_item(item_num)
         self.emit('item-removed', child)
 
-    ############################################################################
-    # EtkDockGroup
-    ############################################################################
-    items = property(lambda s: [t.item for t in s._tabs])
-
-    visible_items = property(lambda s: [t.item for t in s._visible_tabs])
-
-    def __contains__(self, item):
-        return item in self.items
-
     def _update_visible_tabs(self):
-        # Check what tabs we can show with the space we have been allocated.
-        # Tabs on the far right of the current item tab get hidden first,
-        # then tabs on the far left.
+        """Check what tabs we can show with the allocated space.
+
+        Not all tabs are visible if the space allocated is to small. Tabs on
+        the far right of the current item tab get hidden first, then tabs on
+        the far left.
+
+        """
         if not self._tabs:
             del self._visible_tabs[:]
         else:
@@ -914,7 +1051,7 @@ class DockGroup(Gtk.Container):
                     self._visible_tabs.remove(tab)
 
                 # TODO: There are other places where something like this happens,
-                #       notably do_motion_notify_event. Consider some cleanup...
+                # notably do_motion_notify_event. Consider some cleanup...
                 if tab is self._current_tab:
                     tab.button.show()
                 else:
@@ -964,10 +1101,15 @@ class DockGroup(Gtk.Container):
                     self._current_tab.area.width = normal
 
     def set_tab_state(self, tab_state):
-        '''
-        Define the tab state. Normally that will be ``Gtk.StateFlags.SELECTED``, but a
+        """Define the tab state.
+
+        The tab state will Normally that will be Gtk.StateFlags.SELECTED, but a
         different state can be set if required.
-        '''
+
+        Args:
+            tab_state (Gtk.StateFlags): The tab state
+
+        """
         self._tab_state = tab_state
 
         allocation = self.get_allocation()
@@ -977,21 +1119,29 @@ class DockGroup(Gtk.Container):
             )
 
     def get_tab_state(self):
-        '''
-        Current state for drawing tabs.
-        '''
+        """Get current state for drawing tabs.
+
+        Returns:
+            Gtk.StateFlags: The tab state
+
+        """
         return self._tab_state
 
     def get_tab_at_pos(self, x, y):
-        '''
-        :param x: the x coordinate of the position
-        :param y: the y coordinate of the position
-        :returns: the item tab at the position specified by x and y or None
+        """Get the _DockGroupTab at the position.
 
-        The get_tab_at_pos() method returns the _DockGroupTab whose area
-        contains the position specified by x and y or None if no _DockGroupTab
-        area contains position.
-        '''
+        Returns the _DockGroupTab whose area contains the position specified by
+        x and y or None if no _DockGroupTab area contains position.
+
+        Args:
+            x (int): The x coordinate of the position
+            y (int): The y coordinate of the position
+
+        Returns:
+            _DockGroupTab: The item tab at the position specified by x and y
+                           or None
+
+        """
         for tab in self._visible_tabs:
             if (x, y) in tab:
                 return tab
@@ -999,45 +1149,70 @@ class DockGroup(Gtk.Container):
             return None
 
     def append_item(self, item):
-        '''
-        :param item: a DockItem
-        :returns: the index number of the item tab in the DockGroup
+        """Appends a DockItem to the DockGroup.
 
-        The append_item() method appends a DockItem to the DockGroup using the
-        DockItem specified by item.
-        '''
+        Args:
+            item (DockItem): The item to append
+
+        Returns:
+            int: The index number of the item tab in the DockGroup
+
+        """
         return self.insert_item(item)
 
     def prepend_item(self, item):
-        '''
-        :param item: a DockItem
-        :returns: the index number of the item tab in the DockGroup
+        """Prepends a DockItem to the DockGroup.
 
-        The prepend_item() method prepends a DockItem to the DockGroup using the
-        DockItem specified by item.
-        '''
+        Args:
+            item (DockItem): The item to append
+
+        Returns:
+            int: The index number of the item tab in the DockGroup
+
+        """
         return self.insert_item(item, position=0)
 
     def insert_item(self, item, position=None, visible_position=None):
-        '''
-        :param item: a DockItem
-        :param position: the index (starting at 0) at which to insert the item,
-                         or None to append the item after all other item tabs.
-        :param visible_position: the index at which the newly inserted item should
-                         be displayed. This index is usually different from the
-                         position and is normally only used when dropping items on
-                         the group.
-        :returns: the index number of the item tab in the DockGroup
+        """Insert a DockItem into the DockGroup.
 
-        The insert_item() method inserts a DockItem into the DockGroup at the
-        location specified by position (0 is the first item). item is the
-        DockItem to insert. If position is None the item is appended to the
-        DockGroup.
-        '''
-        index = self._insert_item(item, position, visible_position)
-        return index
+        Inserts a DockItem into the DockGroup at the location specified by
+        position (0 is the first item). item is the DockItem to insert. If
+        position is None the item is appended to the DockGroup.
+
+        Args:
+            item (DockItem): The item to append
+            position (int): The index (0 start) at which to insert the item, or
+                None to append the item after all other item tabs.
+            visible_position (int): The index at which the newly inserted item
+                should be displayed. This index is usually different from the
+                position and is normally only used when dropping items on the
+                group.
+
+        Returns:
+            int: The index number of the item tab in the DockGroup.
+
+        """
+        return self._insert_item(item, position, visible_position)
 
     def _insert_item(self, item, position=None, visible_position=None):
+        """Insert a DockItem into the DockGroup (Private).
+
+        Inserts a DockItem into the DockGroup at the location specified by
+        position (0 is the first item). item is the DockItem to insert. If
+        position is None the item is appended to the DockGroup.
+
+        Args:
+            item (DockItem): The item to append
+            position (int); The index (0 start) at which to insert the item, or
+                None to append the item after all other item tabs. visible_position
+            (int): The index at which the newly inserted item should be
+                displayed. This index is usually different from the position and is
+                normally only used when dropping items on the group.
+
+        Returns:
+            int: The index number of the item tab in the DockGroup.
+
+        """
         assert isinstance(item, DockItem)
         assert self.item_num(item) is None
 
@@ -1093,13 +1268,15 @@ class DockGroup(Gtk.Container):
         return item_num
 
     def remove_item(self, item_num):
-        '''
-        :param item_num: the index of an item tab, starting from 0. If None,
-                         the last item will be removed.
+        """Removes the item at the location specified by item_num.
 
-        The remove_item() method removes the item at the location specified by
-        item_num. The value of item_num starts from 0.
-        '''
+        The value of item_num starts from 0.
+
+        Args:
+            item_num (int): The index of an item tab, starting from 0. If None,
+                the last item will be removed.
+
+        """
         if item_num is None:
             tab = self._tabs[-1]
         else:
@@ -1109,67 +1286,81 @@ class DockGroup(Gtk.Container):
         self._remove_item(item)
 
     def item_num(self, item):
-        '''
-        :param item: a DockItem
-        :returns: the index of the item tab specified by item, or None if item
-                  is not in the DockGroup
+        """Returns the index of the item tab which contains the DockItem.
 
-        The item_num() method returns the index of the item tab which contains
-        the DockItem specified by item or None if no item tab contains item.
-        '''
+        Returns None if no item tab contains the item.
+
+        Args:
+            item (DockItem): The item to append
+
+        Returns:
+            int: The index number of the item tab or None
+
+        """
         for tab in self._tabs:
             if tab.item is item:
                 return self._tabs.index(tab)
         return None
 
-    def get_n_items(self):
-        '''
-        :returns: the number of item tabs in the DockGroup.
+    def get_num_items(self):
+        """Gets the number of item tabs in the DockGroup.
 
-        The get_n_items() method returns the number of item tabs in the
-        DockGroup.
-        '''
+        Taking the len of self makes use of the __len__ special metod.
+
+        Returns:
+            int: The number of item tabs
+
+        """
         return len(self)
 
     def get_nth_item(self, item_num):
-        '''
-        :param item_num: the index of an item tab in the DockGroup.
-        :returns: a DockItem, or None if item_num is out of bounds.
+        """Gets the DockItem contained in the item tab.
 
-        The get_nth_item() method returns the DockItem contained in the item tab
-        with the index specified by item_num. If item_num is out of bounds for
-        the item range of the DockGroup this method returns None.
-        '''
+        Returns the DockItem contained in the item tab with the index specified
+        by item_num. If item_num is out of bounds for the item range of the
+        DockGroup this method returns None.
+
+        Args:
+            item_num (int): The index of an item tab in the DockGroup.
+
+        Returns:
+            DockItem: The item.
+
+        """
         if item_num >= 0 and item_num <= len(self._tabs) - 1:
             return self._tabs[item_num].item
         else:
             return None
 
     def get_current_item(self):
-        '''
-        :returns: the index (starting from 0) of the current item tab in the
-                  DockGroup. If the DockGroup has no item tabs, then None will
-                  be returned.
+        """Gets the current item tab.
 
-        The get_current_item() method returns the index of the current item tab
-        numbered from 0, or None if there are no item tabs.
-        '''
+        Returns the index (starting from 0) of the current item tab in the
+        DockGroup. If the DockGroup has no item tabs, then None will be
+        returned.
+
+        Returns:
+            int: The index of the current item tab.
+
+        """
         if self._current_tab:
             return self._tabs.index(self._current_tab)
         else:
             return None
 
     def set_current_item(self, item_num):
-        '''
-        :param item_num: the index of the item tab to switch to, starting from
-                         0. If negative, the first item tab will be used. If
-                         greater than the number of item tabs in the DockGroup,
-                         the last item tab will be used.
+        """Sets the current item.
 
-        Switches to the item number specified by item_num. If item_num is
-        negative the first item is selected. If greater than the number of
-        items in the DockGroup, the last item is selected.
-        '''
+        The index starts at 0. If item_num is negative the first item is
+        selected. If greater than the number of items in the DockGroup, the
+        last item is selected. If negative, the first item tab will be used. If
+        greater than the number of item tabs in the DockGroup, the last item
+        tab will be used.
+
+        Args:
+            item_num (int): The index of the item tab to switch to.
+
+        """
         # Store a reference to the old current tab
         if self._current_tab and self._current_tab in self._tabs:
             old_tab = self._current_tab
@@ -1203,36 +1394,44 @@ class DockGroup(Gtk.Container):
         self.queue_resize()
 
     def next_item(self):
-        '''
-        The next_item() method switches to the next item. Nothing happens if
-        the current item is the last item.
-        '''
+        """Switches to the next item.
+
+        Switches to the next item by adding one to the current item index. If
+        the current item is the last item, then the current item will stay set.
+
+        """
         ci = self.get_current_item()
 
         if not ci == len(self) - 1:
             self.set_current_item(ci + 1)
 
     def prev_item(self):
-        '''
-        The prev_item() method switches to the previous item. Nothing happens
-        if the current item is the first item.
-        '''
+        """Switches to the previous item.
+
+        Switches to the previous item by subtracting one from the current item
+        index. If the current item is the first item, then the current item
+        will stay set.
+
+        """
         ci = self.get_current_item()
 
         if not ci == 0:
             self.set_current_item(ci - 1)
 
     def reorder_item(self, item, position):
-        '''
-        :param item: the DockItem widget to move
-        :param position: the index of the item tab that item is to move to
+        """Reorders the DockGroup items.
 
-        The reorder_item() method reorders the DockGroup items so that item
-        appears in the location specified by position. If position is greater
-        than or equal to the number of children in the list, item will be moved
-        to the end of the list. If position is negative, item will be moved
-        to the beginning of the list.
-        '''
+        Reorders the DockGroup items so that item appears in the location
+        specified by position. If position is greater than or equal to the
+        number of children in the list, item will be moved to the end of the
+        list. If position is negative, item will be moved to the beginning of
+        the list.
+
+        Args:
+            item (DockItem): The DockItem widget to move.
+            position (int): The index of the item tab that item is to move to.
+
+        """
         assert self.item_num(item) is not None
 
         if position < 0:
@@ -1245,18 +1444,20 @@ class DockGroup(Gtk.Container):
         self._tabs.insert(position, tab)
 
     def get_weight(self):
-        """
-        :return: the weight of the DockGroup.
+        """Retrieves the weight of the DockGroup.
 
-        Retrieves the weight of the DockGroup.
+        Returns:
+            float: The weight of the DockGroup.
+
         """
         return self.weight
 
     def set_weight(self, weight):
-        """
-        :param weight: the DockGroup's new orientation.
+        """Sets the weight of the DockGroup.
 
-        Sets the weight of the DockGroup.
+        Args:
+            weight (float): the DockGroup's new weight.
+
         """
         self.weight = weight
 
@@ -1264,6 +1465,12 @@ class DockGroup(Gtk.Container):
     # Property notification signal handlers
     ############################################################################
     def _item_title_changed(self, tab):
+        """Update the tab label after the title has changed.
+
+        Args:
+            tab (_DockGroupTab): The tab for the item.
+
+        """
         tab.label.set_text(tab.item.get_title())
         self.queue_resize()
 
@@ -1275,23 +1482,50 @@ class DockGroup(Gtk.Container):
             tab.menu_item.get_child().set_markup(tab.item.get_title())
 
     def _on_item_title_changed(self, item, pspec, tab):
+        """Call the method to update the tab on the item title changing.
+
+        Args:
+            item (DockItem): The item whose title changed
+            pspec (GObect.ParamSpec): The object structure to specify parameters
+            tab (_DockGroupTab): The tab of the item
+
+        """
         self._item_title_changed(tab)
 
     def _on_item_title_tooltip_text_changed(self, tab):
+        """Called when an item tooltip text updates.
+
+        Args:
+            tab (_DockGroupTab): The tab for the item.
+
+        """
         tab.menu_item.set_tooltip_text(tab.item.get_title_tooltip_text())
 
     ############################################################################
     # Decoration area signal handlers
     ############################################################################
     def _on_tab_button_clicked(self, button, item):
+        """Callback of the clicked signal of an item for the close button.
+
+        Args:
+            button (Gtk.Button): The clicked button
+            item (DockItem): The item to close
+
+        """
         item.close()
 
     def _on_list_button_clicked(self, button):
+        """Callback of the clicked signal when the tab list button is clicked.
+
+        Args:
+            button (Gtk.Button): The button clicked.
+
+        """
         def _menu_position(menu):
             wx, wy = self.window.get_origin()
             x = wx + button.allocation.x
             y = wy + button.allocation.y + button.allocation.height
-            return (x, y, True)
+            return x, y, True
 
         self._list_menu.show_all()
         self._list_menu.popup(parent_menu_shell=None, parent_menu_item=None,
@@ -1299,16 +1533,35 @@ class DockGroup(Gtk.Container):
                               activate_time=0)
 
     def _on_list_menu_item_activated(self, menuitem, tab):
+        """Callback of the clicked signal when the tab menu item is clicked.
+
+        Args:
+            menuitem: The menu item.
+            tab (_DockGroupTab): The tab of the menu item.
+
+        """
         self.set_current_item(self._tabs.index(tab))
 
     def _on_min_button_clicked(self, button):
+        """Callback of the clicked signal for the minimize button.
+
+        Args:
+            button (Gtk.Button): The button clicked.
+
+        """
         # TODO: Hiding the dockgroup is not a good idea, as it will be 'minimized'
-        # into a toolbar, managed by DockLayout. We'll probably want to emit
-        # a signal instead...
-        # self.hide()
+        #   into a toolbar, managed by DockLayout. We'll probably want to emit
+        #   a signal instead...
+        #   self.hide()
         pass
 
     def _on_max_button_clicked(self, button):
+        """Callback of the clicked signal for the maximize button.
+
+        Args:
+            button (Gtk.Button): The button clicked.
+
+        """
         if button.get_icon_name_normal() == 'compact-maximize':
             button.set_icon_name_normal('compact-restore')
             button.set_tooltip_text(_('Restore'))

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -30,11 +30,12 @@ from operator import attrgetter
 from time import time
 
 import cairo
-from gi.repository import GObject
-from gi.repository import Gtk
-import Gtk.gdk as gdk
+import gi
 
-from etkdocking import _
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk, GObject
+
+from . import _
 from .compactbutton import CompactButton
 from .dockitem import DockItem
 from .dnd import DockDragContext, DRAG_TARGET_ITEM_LIST

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -708,7 +708,7 @@ class DockGroup(Gtk.Container):
                     self.dragcontext.dragged_object = [t.item for t in self._tabs]
 
                 if self.dragcontext.dragged_object:
-                    self.drag_begin([DRAG_TARGET_ITEM_LIST], Gdk.DragAction.MOVE,
+                    self.drag_begin(Gtk.TargetList.new([DRAG_TARGET_ITEM_LIST]), Gdk.DragAction.MOVE,
                                     self.dragcontext.source_button, event)
 
             # Update tab button visibility

--- a/etkdocking/dockgroup.py
+++ b/etkdocking/dockgroup.py
@@ -382,7 +382,7 @@ class DockGroup(Gtk.Container):
             iw = max(allocation.width - (2 * self._frame_width) - (2 * self.border_width), 0)
             ih = max(allocation.height - (2 * self._frame_width) - (2 * self.border_width) - 23, 0)
             i_rect.x, i_rect.y, i_rect.w, i_rect.h = ix, iy, iw, ih
-            self._current_tab.item.size_allocate(item_rect)
+            self._current_tab.item.size_allocate(i_rect)
 
         # assert not self._current_tab or self._current_tab in self._visible_tabs
         self.queue_draw_area(0, 0, self.allocation.width, self.allocation.height)

--- a/etkdocking/dockitem.py
+++ b/etkdocking/dockitem.py
@@ -23,49 +23,49 @@ from __future__ import absolute_import
 from builtins import hex
 from logging import getLogger
 
-import gobject
-import gtk
-import gtk.gdk as gdk
+from gi.repository import GObject
+from gi.repository import Gtk
+import Gtk.gdk as gdk
 
 
-class DockItem(gtk.Bin):
+class DockItem(Gtk.Bin):
     __gtype_name__ = 'EtkDockItem'
     __gproperties__ = {'title':
-                           (gobject.TYPE_STRING,
+                           (GObject.TYPE_STRING,
                             'Title',
                             'The title for the DockItem.',
                             '',
-                            gobject.PARAM_READWRITE),
+                            GObject.PARAM_READWRITE),
                        'title-tooltip-text':
-                           (gobject.TYPE_STRING,
+                           (GObject.TYPE_STRING,
                             'Title tooltip text',
                             'The tooltip text for the title.',
                             '',
-                            gobject.PARAM_READWRITE),
+                            GObject.PARAM_READWRITE),
                        'icon-name':
-                           (gobject.TYPE_STRING,
+                           (GObject.TYPE_STRING,
                             'Icon name',
                             'The name of the icon from the icon theme.',
                             '',
-                            gobject.PARAM_READWRITE),
+                            GObject.PARAM_READWRITE),
                        'stock':
-                           (gobject.TYPE_STRING,
+                           (GObject.TYPE_STRING,
                             'Stock',
                             'Stock ID for a stock image to display.',
                             '',
-                            gobject.PARAM_READWRITE),
+                            GObject.PARAM_READWRITE),
                        'image':
-                           (gobject.TYPE_PYOBJECT,
+                           (GObject.TYPE_PYOBJECT,
                             'Image',
-                            'The image constructed from the specified stock ID or icon-name. Default value is gtk.STOCK_MISSING_IMAGE.',
-                            gobject.PARAM_READABLE)}
+                            'The image constructed from the specified stock ID or icon-name. Default value is Gtk.STOCK_MISSING_IMAGE.',
+                            GObject.PARAM_READABLE)}
     __gsignals__ = {'close':
-                        (gobject.SIGNAL_RUN_LAST,
-                         gobject.TYPE_NONE, ())}
+                        (GObject.SignalFlags.RUN_LAST,
+                         None, ())}
 
     def __init__(self, title='', title_tooltip_text='', icon_name=None, stock_id=None):
-        gtk.Bin.__init__(self)
-        self.set_flags(self.flags() | gtk.NO_WINDOW)
+        GObject.GObject.__init__(self)
+        self.set_flags(self.flags() | Gtk.NO_WINDOW)
         self.set_redraw_on_allocate(False)
 
         # Initialize logging
@@ -135,11 +135,11 @@ class DockItem(gtk.Bin):
 
     def get_image(self):
         if self._icon_name:
-            return gtk.image_new_from_icon_name(self._icon_name, gtk.ICON_SIZE_MENU)
+            return Gtk.Image.new_from_icon_name(self._icon_name, Gtk.IconSize.MENU)
         elif self._stock_id:
-            return gtk.image_new_from_stock(self._stock_id, gtk.ICON_SIZE_MENU)
+            return Gtk.Image.new_from_stock(self._stock_id, Gtk.IconSize.MENU)
         else:
-            return gtk.Image()
+            return Gtk.Image()
 
     title = property(get_title, set_title)
     title_tooltip_text = property(get_title_tooltip_text, set_title_tooltip_text)
@@ -153,21 +153,21 @@ class DockItem(gtk.Bin):
         requisition.width = 0
         requisition.height = 0
 
-        if self.child and self.child.flags() & gtk.VISIBLE:
-            (requisition.width, requisition.height) = self.child.size_request()
+        if self.get_child() and self.get_child().flags() & Gtk.VISIBLE:
+            (requisition.width, requisition.height) = self.get_child().size_request()
             requisition.width += self.border_width * 2
             requisition.height += self.border_width * 2
 
     def do_size_allocate(self, allocation):
         self.allocation = allocation
 
-        if self.child and self.child.flags() & gtk.VISIBLE:
-            child_allocation = gdk.Rectangle()
+        if self.get_child() and self.get_child().flags() & Gtk.VISIBLE:
+            child_allocation = ()
             child_allocation.x = allocation.x + self.border_width
             child_allocation.y = allocation.y + self.border_width
             child_allocation.width = allocation.width - (2 * self.border_width)
             child_allocation.height = allocation.height - (2 * self.border_width)
-            self.child.size_allocate(child_allocation)
+            self.get_child().size_allocate(child_allocation)
 
     ############################################################################
     # DockItem

--- a/etkdocking/dockitem.py
+++ b/etkdocking/dockitem.py
@@ -157,16 +157,16 @@ class DockItem(Gtk.Bin):
         requisition.width = 0
         requisition.height = 0
 
-        if self.get_child() and self.get_child().flags() & Gtk.VISIBLE:
-            (requisition.width, requisition.height) = self.get_child().size_request()
+        if self.get_child() and self.get_child().props.visible:
+            (requisition.width, requisition.height) = self.child.size_request()
             requisition.width += self.border_width * 2
             requisition.height += self.border_width * 2
 
     def do_size_allocate(self, allocation):
-        self.allocation = allocation
+        self.border_width = self.get_border_width()
 
-        if self.get_child() and self.get_child().flags() & Gtk.VISIBLE:
-            child_allocation = ()
+        if self.get_child() and self.get_child().props.visible:
+            child_allocation = Gdk.Rectangle()
             child_allocation.x = allocation.x + self.border_width
             child_allocation.y = allocation.y + self.border_width
             child_allocation.width = allocation.width - (2 * self.border_width)

--- a/etkdocking/dockitem.py
+++ b/etkdocking/dockitem.py
@@ -36,30 +36,30 @@ class DockItem(Gtk.Bin):
                             'Title',
                             'The title for the DockItem.',
                             '',
-                            GObject.PARAM_READWRITE),
+                            GObject.ParamFlags.READWRITE),
                        'title-tooltip-text':
                            (GObject.TYPE_STRING,
                             'Title tooltip text',
                             'The tooltip text for the title.',
                             '',
-                            GObject.PARAM_READWRITE),
+                            GObject.ParamFlags.READWRITE),
                        'icon-name':
                            (GObject.TYPE_STRING,
                             'Icon name',
                             'The name of the icon from the icon theme.',
                             '',
-                            GObject.PARAM_READWRITE),
+                            GObject.ParamFlags.READWRITE),
                        'stock':
                            (GObject.TYPE_STRING,
                             'Stock',
                             'Stock ID for a stock image to display.',
                             '',
-                            GObject.PARAM_READWRITE),
+                            GObject.ParamFlags.READWRITE),
                        'image':
                            (GObject.TYPE_PYOBJECT,
                             'Image',
                             'The image constructed from the specified stock ID or icon-name. Default value is Gtk.STOCK_MISSING_IMAGE.',
-                            GObject.PARAM_READABLE)}
+                            GObject.ParamFlags.READABLE)}
     __gsignals__ = {'close':
                         (GObject.SignalFlags.RUN_LAST,
                          None, ())}

--- a/etkdocking/dockitem.py
+++ b/etkdocking/dockitem.py
@@ -23,9 +23,10 @@ from __future__ import absolute_import
 from builtins import hex
 from logging import getLogger
 
-from gi.repository import GObject
-from gi.repository import Gtk
-import Gtk.gdk as gdk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk, GObject
 
 
 class DockItem(Gtk.Bin):

--- a/etkdocking/dockitem.py
+++ b/etkdocking/dockitem.py
@@ -67,8 +67,7 @@ class DockItem(Gtk.Bin):
     def __init__(self, title='', title_tooltip_text='', icon_name=None, stock_id=None):
         Gtk.Bin.__init__(self)
 
-        # TODO this PyGTK Specific
-        # self.set_flags(self.flags() | Gtk.NO_WINDOW)
+        self.set_has_window(False)
 
         self.set_redraw_on_allocate(False)
 

--- a/etkdocking/dockitem.py
+++ b/etkdocking/dockitem.py
@@ -65,7 +65,7 @@ class DockItem(Gtk.Bin):
                          None, ())}
 
     def __init__(self, title='', title_tooltip_text='', icon_name=None, stock_id=None):
-        GObject.GObject.__init__(self)
+        Gtk.Bin.__init__(self)
 
         # TODO this PyGTK Specific
         # self.set_flags(self.flags() | Gtk.NO_WINDOW)

--- a/etkdocking/dockitem.py
+++ b/etkdocking/dockitem.py
@@ -66,7 +66,10 @@ class DockItem(Gtk.Bin):
 
     def __init__(self, title='', title_tooltip_text='', icon_name=None, stock_id=None):
         GObject.GObject.__init__(self)
-        self.set_flags(self.flags() | Gtk.NO_WINDOW)
+
+        # TODO this PyGTK Specific
+        # self.set_flags(self.flags() | Gtk.NO_WINDOW)
+
         self.set_redraw_on_allocate(False)
 
         # Initialize logging

--- a/etkdocking/dockitem.py
+++ b/etkdocking/dockitem.py
@@ -30,6 +30,13 @@ from gi.repository import Gtk, Gdk, GObject
 
 
 class DockItem(Gtk.Bin):
+    """DockItems are added as tabs to a DockGroup.
+
+    DockItems have an icon image, a title, tooltip, and use the CompactButtons
+    for user input for things like requesting that the tab is closed or
+    maximized. Each DockItem is a Gtk.Bin and can have a single child widget.
+
+    """
     __gtype_name__ = 'EtkDockItem'
     __gproperties__ = {'title':
                            (GObject.TYPE_STRING,
@@ -87,6 +94,15 @@ class DockItem(Gtk.Bin):
     # GObject
     ############################################################################
     def do_get_property(self, pspec):
+        """Gets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): A property of the CompactButton.
+
+        Returns:
+            The parameter value.
+
+        """
         if pspec.name == 'title':
             return self.get_title()
         elif pspec.name == 'title-tooltip-text':
@@ -99,6 +115,13 @@ class DockItem(Gtk.Bin):
             return self.get_image()
 
     def do_set_property(self, pspec, value):
+        """Sets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): The property of the CompactButton to set.
+            value: the value to set.
+
+        """
         if pspec.name == 'title':
             self.set_title(value)
         elif pspec.name == 'title-tooltip-text':
@@ -109,34 +132,91 @@ class DockItem(Gtk.Bin):
             self.set_stock(value)
 
     def get_title(self):
+        """Get title of DockItem.
+
+        Returns:
+            string: Title of DockItem.
+
+        """
         return self._title
 
     def set_title(self, text):
+        """Set title of DockItem.
+
+        Args:
+            text (string): Text to set title of DockItem to.
+
+        """
         self._title = text
         self.notify('title')
 
     def get_title_tooltip_text(self):
+        """Get tooltip text of DockItem title that is displayed on hover.
+
+        Returns:
+            string: Tooltip text of title.
+
+        """
         return self._title_tooltip_text
 
     def set_title_tooltip_text(self, text):
+        """Set tootip text of DockItem title that is displayed on hover.
+
+        Args:
+            text (string): Text to set tooltip to.
+
+        """
         self._title_tooltip_text = text
         self.notify('title-tooltip-text')
 
     def get_icon_name(self):
+        """Get icon name of DockItem.
+
+        Returns:
+            string: Icon name.
+
+        """
         return self._icon_name
 
     def set_icon_name(self, icon_name):
+        """Set icon name of DockItem.
+
+        Args:
+            icon_name (string): Icon name to set.
+
+        """
         self._icon_name = icon_name
         self.notify('icon-name')
 
     def get_stock(self):
+        """Gets the icon stock id.
+
+        TODO: stock has been deprecated in Gtk+
+
+        Returns:
+
+        """
         return self._stock_id
 
     def set_stock(self, stock_id):
+        """Sets the icon stock id.
+
+        TODO: stock has been deprecated in Gtk+
+
+        Args:
+            stock_id (string): A stock icon name.
+
+        """
         self._stock_id = stock_id
         self.notify('stock')
 
     def get_image(self):
+        """Gets the Gtk.Image for the DockItem.
+
+        Returns:
+            Gtk.Image: The image displayed in the DockItem tab.
+
+        """
         if self._icon_name:
             return Gtk.Image.new_from_icon_name(self._icon_name, Gtk.IconSize.MENU)
         elif self._stock_id:
@@ -150,42 +230,57 @@ class DockItem(Gtk.Bin):
     stock = property(get_stock, set_stock)
 
     ############################################################################
-    # GtkContainer
+    # Gtk.Container
     ############################################################################
     def do_child_type(self):
-        """Indicates that this container accepts any GTK+ widget."""
+        """Indicates that this container accepts any GTK+ widget.
+
+            Returns:
+                GObject.GType: The type of children supported by the Container.
+        """
         return Gtk.Widget.get_type()
 
     def do_forall(self, include_internals, callback, *callback_data):
-        """Invokes the given callback on the child widget, with the given data.
+        """Invokes the given callback on each tab, with the given data.
 
-        @param include_internals Whether to run on internal children as well, as
-                                 boolean. Ignored, as there are no internal
-                                 children.
-        @param callback The callback to call on the child, as Gtk.Callback
-        @param callback_data The parameters to pass to the callback, as object
-                             or None
+        Args:
+            include_internals (bool): Run on internal children
+            callback (Gtk.Callback): The callback to call on each child
+            callback_data (object or None): The parameters to pass to the
+                callback
+
         """
         child = self.get_child()
         if include_internals and child:
             callback(child, *callback_data)
 
     ############################################################################
-    # GtkWidget
+    # Gtk.Widget
     ############################################################################
     def do_get_request_mode(self):
-        """Returns whether the DockItem prefers a height-for-width or a
-        width-for-height layout. DockItem doesn't trade width for height or
+        """Returns the preferred container layout.
+
+        Returns whether the container prefers a height-for-width or a
+        width-for-height layout. DockGroup doesn't trade width for height or
         height for width so we return CONSTANT_SIZE.
+
+        Returns:
+            Gtk.SizeRequestMode: the constant size request mode.
+
         """
         return Gtk.SizeRequestMode.CONSTANT_SIZE
 
     def do_get_preferred_height(self):
-        """Calculates the DockItem's initial minimum and natural height. While
-        this call is specific to width-for-height requests (that we requested
-        not to get) we cannot be certain that our wishes are granted, so we
-        must implement this method as well. Returns the preferred height of the
-        child widget with padding added for the border width.
+        """Calculates the DockItem's initial minimum and natural height.
+
+        While this call is specific to width-for-height requests (that we requested
+        not to get) we cannot be certain that our wishes are granted, so
+        we must implement this method as well. Returns the the decoration area
+        height.
+
+        Returns:
+             int: minimum height, natural height.
+
         """
         minimum_height = 0
         natural_height = 0
@@ -197,11 +292,16 @@ class DockItem(Gtk.Bin):
         return minimum_height, natural_height
 
     def do_get_preferred_width(self):
-        """Calculates the DockItem's initial minimum and natural width. While
-        this call is specific to width-for-height requests (that we requested
-        not to get) we cannot be certain that our wishes are granted, so
-        we must implement this method as well. Returns the preferred width of
-        the child widget with padding added for the border width.
+        """Calculates the container's initial minimum and natural width.
+
+        While this call is specific to width-for-height requests (that we
+        requested not to get) we cannot be certain that our wishes are granted,
+        so we must implement this method as well. Returns the decoration area
+        width.
+
+        Returns:
+            int: minimum width, natural width
+
         """
         minimum_width = 0
         natural_width = 0
@@ -213,30 +313,53 @@ class DockItem(Gtk.Bin):
         return minimum_width, natural_width
 
     def do_get_preferred_height_for_width(self, width):
-        """Returns this DockItem's minimum and natural height if it would be
-        given the specified width. While this call is specific to
-        height-for-width requests (that we requested not to get) we cannot be
-        certain that our wishes are granted, so we must implement this method
-        as well. Since we really want to be the same size always, we simply
-        return do_get_preferred_height.
+        """If given width, returns the minimum and natural height.
 
-        @param width The given width, as int. Ignored.
+        Returns the DockItem's minimum and natural height if given the
+        specified width. While this call is specific to height-for-width
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_height.
+
+        Args:
+            width (int): The given width. Ignored.
+
+        Returns:
+            int: minimum height, natural height
+
         """
         return self.do_get_preferred_height()
 
     def do_get_preferred_width_for_height(self, height):
-        """Returns this DockItem's minimum and natural width if it would be
-        given the specified height. While this call is specific to
-        width-for-height requests (that we requested not to get) we cannot be
-        certain that our wishes are granted, so we must implement this method
-        as well. Since we really want to be the same size always, we simply
-        return do_get_preferred_width.
+        """If given height, returns the minimum and natural width.
 
-        @param height The given height, as int. Ignored.
+        Returns the DockItem's minimum and natural width if given the
+        specified height. While this call is specific to width-for-height
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_width.
+
+        Args:
+            height (int): The given height. Ignored.
+
+        Returns:
+            int: minimum width, natural width.
+
         """
         return self.do_get_preferred_width()
 
     def do_size_allocate(self, allocation):
+        """Assigns a size and position to DockItem's child widget.
+
+        The child may adjust the given allocation in the adjust_size_allocation
+        virtual method.
+
+        Args:
+            allocation (Gdk.Rectangle): Position and size allocated.
+
+        """
         self.border_width = self.get_border_width()
         child = self.get_child()
 
@@ -252,9 +375,15 @@ class DockItem(Gtk.Bin):
     # DockItem
     ############################################################################
     def do_close(self):
+        """Removes the DockItem from the parent DockGroup.
+
+        """
         group = self.get_parent()
         if group:
             group.remove(self)
 
     def close(self):
+        """Emits the close signal on the DockItem.
+
+        """
         self.emit('close')

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -28,9 +28,9 @@ from logging import getLogger
 
 from simplegeneric import generic
 
-import gobject
-import gtk
-import gtk.gdk as gdk
+from gi.repository import GObject
+from gi.repository import Gtk
+import Gtk.gdk as gdk
 import itertools
 from weakref import WeakKeyDictionary
 
@@ -52,7 +52,7 @@ MAGIC_BORDER_SIZE = 10
 DragData = namedtuple('DragData', 'drop_widget leave received')
 
 
-class DockLayout(gobject.GObject):
+class DockLayout(GObject.GObject):
     """
     Manage a dock layout.
 
@@ -66,14 +66,14 @@ class DockLayout(gobject.GObject):
 
     __gtype_name__ = 'EtkDockLayout'
     __gsignals__ = {
-        'item-closed': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
-                        (gobject.TYPE_OBJECT, gobject.TYPE_OBJECT)),
-        'item-selected': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
-                          (gobject.TYPE_OBJECT, gobject.TYPE_OBJECT)),
+        'item-closed': (GObject.SignalFlags.RUN_LAST, None,
+                        (GObject.TYPE_OBJECT, GObject.TYPE_OBJECT)),
+        'item-selected': (GObject.SignalFlags.RUN_LAST, None,
+                          (GObject.TYPE_OBJECT, GObject.TYPE_OBJECT)),
     }
 
     def __init__(self):
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))
@@ -101,16 +101,16 @@ class DockLayout(gobject.GObject):
         Get the frames that are non-floating (the main frames).
         """
         return (f for f in self.frames \
-                if not (isinstance(f.get_parent(), gtk.Window) \
+                if not (isinstance(f.get_parent(), Gtk.Window) \
                         and f.get_parent().get_transient_for()))
 
     def get_floating_frames(self):
         """
-        Get the floating frames. Floating frames have a gtk.Window as parent that is
+        Get the floating frames. Floating frames have a Gtk.Window as parent that is
         transient for some other window.
         """
         return (f for f in self.frames \
-                if isinstance(f.get_parent(), gtk.Window) \
+                if isinstance(f.get_parent(), Gtk.Window) \
                 and f.get_parent().get_transient_for())
 
     def get_widgets(self, name):
@@ -133,7 +133,7 @@ class DockLayout(gobject.GObject):
                        ('item-selected', self.on_dockgroup_item_selected))
         elif isinstance(widget, DockItem):
             signals = (('close', self.on_dockitem_close),)
-        elif isinstance(widget, gtk.Container):
+        elif isinstance(widget, Gtk.Container):
             signals = (('add', self.on_widget_add),
                        ('remove', self.on_widget_remove))
         else:
@@ -159,8 +159,8 @@ class DockLayout(gobject.GObject):
         drag_dest = widget.drag_dest_get_target_list()
 
         if not drag_dest:
-            widget.drag_dest_set(gtk.DEST_DEFAULT_MOTION, [DRAG_TARGET_ITEM_LIST],
-                                 gdk.ACTION_MOVE)
+            widget.drag_dest_set(Gtk.DestDefaults.MOTION, [DRAG_TARGET_ITEM_LIST],
+                                 Gdk.DragAction.MOVE)
         elif DRAG_TARGET_ITEM_LIST not in drag_dest:
             widget.drag_dest_set_target_list(drag_dest + [DRAG_TARGET_ITEM_LIST])
 
@@ -173,12 +173,12 @@ class DockLayout(gobject.GObject):
 
         self._signal_handlers[widget] = signals
 
-        if isinstance(widget, gtk.Container):
+        if isinstance(widget, Gtk.Container):
             widget.foreach(self.add_signal_handlers)
 
         # Ensure SELECTED state is only for the selected item
         if isinstance(widget, DockGroup):
-            widget.set_tab_state(gtk.STATE_PRELIGHT)
+            widget.set_tab_state(Gtk.StateType.PRELIGHT)
 
     def remove_signal_handlers(self, widget):
         """
@@ -196,7 +196,7 @@ class DockLayout(gobject.GObject):
 
             # TODO: widget.drag_dest_set_target_list(drag_dest - [DRAG_TARGET_ITEM_LIST])??
 
-            if isinstance(widget, gtk.Container):
+            if isinstance(widget, Gtk.Container):
                 widget.foreach(self.remove_signal_handlers)
 
     def update_floating_window_title(self, widget):
@@ -218,18 +218,18 @@ class DockLayout(gobject.GObject):
         # Use this callback to grey out the selection on all but the active selection?
         self._focused_item = item
 
-        if not (group is self._focused_group and group.get_tab_state() != gtk.STATE_PRELIGHT):
+        if not (group is self._focused_group and group.get_tab_state() != Gtk.StateType.PRELIGHT):
             if self._focused_group:
-                self._focused_group.set_tab_state(gtk.STATE_PRELIGHT)
+                self._focused_group.set_tab_state(Gtk.StateType.PRELIGHT)
 
             self._focused_group = group
-            group.set_tab_state(gtk.STATE_SELECTED)
+            group.set_tab_state(Gtk.StateType.SELECTED)
 
     def on_widget_add(self, container, widget):
         """
         Deal with new elements being added to the layout or it's children.
         """
-        if isinstance(widget, gtk.Container):
+        if isinstance(widget, Gtk.Container):
             self.add_signal_handlers(widget)
 
         self.update_floating_window_title(container)
@@ -238,7 +238,7 @@ class DockLayout(gobject.GObject):
         """
         Remove signals from containers and subcontainers.
         """
-        if isinstance(widget, gtk.Container):
+        if isinstance(widget, Gtk.Container):
             self.remove_signal_handlers(widget)
 
         self.update_floating_window_title(container)
@@ -271,7 +271,7 @@ class DockLayout(gobject.GObject):
             drag_data = self._drag_data
 
             if drag_data and drag_data.drop_widget:
-                target = gdk.atom_intern(DRAG_TARGET_ITEM_LIST[0])
+                target = Gdk.atom_intern(DRAG_TARGET_ITEM_LIST[0])
                 drag_data.drop_widget.drag_get_data(context, target, timestamp)
                 return True
 
@@ -347,19 +347,19 @@ class DockLayout(gobject.GObject):
 ################################################################################
 
 def add_new_group_left(widget, new_group):
-    add_new_group_before(widget, new_group, gtk.ORIENTATION_HORIZONTAL)
+    add_new_group_before(widget, new_group, Gtk.Orientation.HORIZONTAL)
 
 
 def add_new_group_right(widget, new_group):
-    add_new_group_after(widget, new_group, gtk.ORIENTATION_HORIZONTAL)
+    add_new_group_after(widget, new_group, Gtk.Orientation.HORIZONTAL)
 
 
 def add_new_group_above(widget, new_group):
-    add_new_group_before(widget, new_group, gtk.ORIENTATION_VERTICAL)
+    add_new_group_before(widget, new_group, Gtk.Orientation.VERTICAL)
 
 
 def add_new_group_below(widget, new_group):
-    add_new_group_after(widget, new_group, gtk.ORIENTATION_VERTICAL)
+    add_new_group_after(widget, new_group, Gtk.Orientation.VERTICAL)
 
 
 def add_new_group_before(widget, new_group, orientation):
@@ -433,7 +433,7 @@ def _window_delete_handler(window, event):
 
 
 def add_new_group_floating(new_group, layout, size=None, pos=None):
-    window = gtk.Window(gtk.WINDOW_TOPLEVEL)
+    window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
 
     if pos:
         window.move(*pos)
@@ -441,7 +441,7 @@ def add_new_group_floating(new_group, layout, size=None, pos=None):
     window.set_resizable(True)
     window.set_skip_taskbar_hint(True)
     if PROVIDE_FLOATING_WINDOW_HINTS:
-        window.set_type_hint(gdk.WINDOW_TYPE_HINT_UTILITY)
+        window.set_type_hint(Gdk.WindowTypeHint.UTILITY)
     window.set_transient_for(layout.get_main_frames().next().get_toplevel())
 
     if size:
@@ -508,7 +508,7 @@ def magic_borders(widget, context, x, y, timestamp):
 @generic
 def drag_motion(widget, context, x, y, timestamp):
     '''
-    :param context: the gdk.DragContext
+    :param context: the Gdk.DragContext
     :param x: the X position of the drop
     :param y: the Y position of the drop
     :param timestamp: the time of the drag event
@@ -521,11 +521,11 @@ def drag_motion(widget, context, x, y, timestamp):
     it should return False and no further processing is necessary. Otherwise,
     the handler should return True. In this case, the handler is responsible
     for providing the necessary information for displaying feedback to the
-    user, by calling the gdk.DragContext.drag_status() method. If the
+    user, by calling the Gdk.DragContext.drag_status() method. If the
     decision to accept or reject the drop can't be made based solely on
     the cursor position and the type of the data, the handler may inspect
     the dragged data by calling the drag_get_data() method and defer the
-    gdk.DragContext.drag_status() method call to the do_drag_data_received()
+    Gdk.DragContext.drag_status() method call to the do_drag_data_received()
     signal handler.
 
     Note::
@@ -541,11 +541,11 @@ def drag_motion(widget, context, x, y, timestamp):
     The do_drag_data_received() signal handler is executed when the drag
     destination receives the data from the drag operation. If the data was
     received in order to determine whether the drop will be accepted, the
-    handler is expected to call the gdk.DragContext.drag_status() method
+    handler is expected to call the Gdk.DragContext.drag_status() method
     and not finish the drag. If the data was received in response to a
     do_drag_drop() signal (and this is the last target to be received),
     the handler for this signal is expected to process the received data
-    and then call the gdk.DragContext.finish() method, setting the success
+    and then call the Gdk.DragContext.finish() method, setting the success
     parameter to True if the data was processed successfully.
     '''
     return _propagate_to_parent(drag_motion, widget, context, x, y, timestamp)
@@ -566,7 +566,7 @@ def cleanup(widget, layout):
 @generic
 def drag_end(widget, context):
     '''
-    :param context: the gdk.DragContext
+    :param context: the Gdk.DragContext
 
     The do_drag_end() signal handler is executed when the drag operation is
     completed. A typical reason to use this signal handler is to undo things
@@ -579,7 +579,7 @@ def drag_end(widget, context):
 @generic
 def drag_failed(widget, context, result):
     '''
-    :param context: the gdk.DragContext
+    :param context: the Gdk.DragContext
     :param result: the result of the drag operation
     :returns: True if the failed drag operation has been already handled.
 
@@ -696,7 +696,7 @@ def dock_group_drag_end(self, context):
 def dock_group_drag_failed(self, context, result):
     global settings
     self.log.debug('%s, %s' % (context, result))
-    if result == 1 and settings[self].can_float:  # gtk.DRAG_RESULT_NO_TARGET
+    if result == 1 and settings[self].can_float:  # Gtk.DRAG_RESULT_NO_TARGET
         if reduce(lambda a, b: a or b,
                   [settings[i].float_retain_size for i in self.dragcontext.dragged_object]):
             size = (self.allocation.width, self.allocation.height)
@@ -848,10 +848,10 @@ def dock_paned_magic_borders(self, context, x, y, timestamp):
         placeholder.show()
 
         if create:
-            if self.get_orientation() == gtk.ORIENTATION_HORIZONTAL:
-                orientation = gtk.ORIENTATION_VERTICAL
+            if self.get_orientation() == Gtk.Orientation.HORIZONTAL:
+                orientation = Gtk.Orientation.VERTICAL
             else:
-                orientation = gtk.ORIENTATION_HORIZONTAL
+                orientation = Gtk.Orientation.HORIZONTAL
 
             weight = self.child_get_property(current_group, 'weight')
 
@@ -895,10 +895,10 @@ def dock_paned_magic_borders(self, context, x, y, timestamp):
             return add_group_receiver
 
     if abs(min(y, a.height - y)) < MAGIC_BORDER_SIZE:
-        received = create_received(self.get_orientation() == gtk.ORIENTATION_HORIZONTAL)
+        received = create_received(self.get_orientation() == Gtk.Orientation.HORIZONTAL)
         return DragData(self, dock_paned_magic_borders_leave, received)
     elif abs(min(x, a.width - x)) < MAGIC_BORDER_SIZE:
-        received = create_received(self.get_orientation() == gtk.ORIENTATION_VERTICAL)
+        received = create_received(self.get_orientation() == Gtk.Orientation.VERTICAL)
         return DragData(self, dock_paned_magic_borders_leave, received)
 
     return None
@@ -943,17 +943,17 @@ def dock_frame_magic_borders(self, context, x, y, timestamp):
     border = self.border_width
 
     if x - border < MAGIC_BORDER_SIZE:
-        orientation = gtk.ORIENTATION_HORIZONTAL
+        orientation = Gtk.Orientation.HORIZONTAL
         allocation = (a.x + border, a.y + border, MAGIC_BORDER_SIZE, a.height - border * 2)
     elif a.width - x - border < MAGIC_BORDER_SIZE:
-        orientation = gtk.ORIENTATION_HORIZONTAL
+        orientation = Gtk.Orientation.HORIZONTAL
         allocation = (
         a.x + a.width - MAGIC_BORDER_SIZE - border, a.y + border, MAGIC_BORDER_SIZE, a.height - border * 2)
     elif y - border < MAGIC_BORDER_SIZE:
-        orientation = gtk.ORIENTATION_VERTICAL
+        orientation = Gtk.Orientation.VERTICAL
         allocation = (a.x + border, a.y + border, a.width - border * 2, MAGIC_BORDER_SIZE)
     elif a.height - y - border < MAGIC_BORDER_SIZE:
-        orientation = gtk.ORIENTATION_VERTICAL
+        orientation = Gtk.Orientation.VERTICAL
         allocation = (
         a.x + border, a.y + a.height - MAGIC_BORDER_SIZE - border, a.width - border * 2, MAGIC_BORDER_SIZE)
     else:

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -156,13 +156,17 @@ class DockLayout(GObject.GObject):
             return
 
         signals = set()
-        drag_dest = widget.drag_dest_get_target_list()
+        dest_target_list = widget.drag_dest_get_target_list()
 
-        if not drag_dest:
-            widget.drag_dest_set(Gtk.DestDefaults.MOTION, [DRAG_TARGET_ITEM_LIST],
-                                 Gdk.DragAction.MOVE)
-        elif DRAG_TARGET_ITEM_LIST not in drag_dest:
-            widget.drag_dest_set_target_list(drag_dest + [DRAG_TARGET_ITEM_LIST])
+        if not dest_target_list:
+            widget.drag_dest_set(
+                flags=Gtk.DestDefaults.MOTION,
+                targets=[DRAG_TARGET_ITEM_LIST],
+                actions=Gdk.DragAction.MOVE
+            )
+        elif not dest_target_list.find(Gdk.Atom.intern("x-etk-docking/item-list", False)):
+            updated_target_list = dest_target_list.add_table([DRAG_TARGET_ITEM_LIST])
+            widget.drag_dest_set_target_list(updated_target_list)
 
         # Use instance methods here, so layout can do additional bookkeeping
         for name, callback in self._get_signals(widget):

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -248,7 +248,7 @@ class DockLayout(GObject.GObject):
         self.update_floating_window_title(container)
 
     def on_widget_drag_motion(self, widget, context, x, y, timestamp):
-        if DRAG_TARGET_ITEM_LIST[0] in context.targets:
+        if DRAG_TARGET_ITEM_LIST.target in context.targets:
             context.docklayout = self
             drag_data = drag_motion(widget, context, x, y, timestamp)
 
@@ -261,7 +261,7 @@ class DockLayout(GObject.GObject):
 
     def on_widget_drag_leave(self, widget, context, timestamp):
         # Note: when dropping, drag-leave is invoked before drag-drop
-        if DRAG_TARGET_ITEM_LIST[0] in context.targets:
+        if DRAG_TARGET_ITEM_LIST.target in context.targets:
             drag_data = self._drag_data
 
             if drag_data and drag_data.leave:
@@ -271,11 +271,11 @@ class DockLayout(GObject.GObject):
     def on_widget_drag_drop(self, widget, context, x, y, timestamp):
         self.log.debug('drag_drop %s %s %s %s', context, x, y, timestamp)
 
-        if DRAG_TARGET_ITEM_LIST[0] in context.targets:
+        if DRAG_TARGET_ITEM_LIST.target in context.targets:
             drag_data = self._drag_data
 
             if drag_data and drag_data.drop_widget:
-                target = Gdk.atom_intern(DRAG_TARGET_ITEM_LIST[0])
+                target = Gdk.atom_intern(DRAG_TARGET_ITEM_LIST.target)
                 drag_data.drop_widget.drag_get_data(context, target, timestamp)
                 return True
 
@@ -293,7 +293,7 @@ class DockLayout(GObject.GObject):
         '''
         self.log.debug('drag_data_received %s, %s, %s, %s, %s, %s' % (context, x, y, selection_data, info, timestamp))
 
-        if DRAG_TARGET_ITEM_LIST[0] in context.targets:
+        if DRAG_TARGET_ITEM_LIST.target in context.targets:
             drag_data = self._drag_data
             assert drag_data.received
 
@@ -303,12 +303,12 @@ class DockLayout(GObject.GObject):
                 self._drag_data = None
 
     def on_widget_drag_end(self, widget, context):
-        if DRAG_TARGET_ITEM_LIST[0] in context.targets:
+        if DRAG_TARGET_ITEM_LIST.target in context.targets:
             context.docklayout = self
             return drag_end(widget, context)
 
     def on_widget_drag_failed(self, widget, context, result):
-        if DRAG_TARGET_ITEM_LIST[0] in context.targets:
+        if DRAG_TARGET_ITEM_LIST.target in context.targets:
             context.docklayout = self
             return drag_failed(widget, context, result)
 

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -613,29 +613,29 @@ def new(class_, old=None, layout=None):
     return new
 
 
-def dock_group_expose_highlight(self, event):
+def dock_group_draw_highlight(self, da, ctx):
+    alloc = da.get_allocation()
     try:
         tab = self._visible_tabs[self._drop_tab_index]
     except TypeError:
-        a = event.area
+        a = alloc
     else:
         if tab is self._current_tab:
-            a = event.area
+            a = alloc
         else:
             a = tab.area
 
-    cr = self.window.cairo_create()
-    cr.set_source_rgb(0, 0, 0)
-    cr.set_line_width(1.0)
-    cr.rectangle(a.x + 0.5, a.y + 0.5, a.width - 1, a.height - 1)
-    cr.stroke()
+    ctx = self.window.cairo_create()
+    ctx.set_source_rgb(0, 0, 0)
+    ctx.set_line_width(1.0)
+    ctx.rectangle(a.x + 0.5, a.y + 0.5, a.width - 1, a.height - 1)
+    ctx.stroke()
 
 
 def dock_group_highlight(self):
-    if not hasattr(self, '_expose_event_id'):
-        self.log.debug('attaching expose event')
-        self._expose_event_id = self.connect_after('expose-event',
-                                                   dock_group_expose_highlight)
+    if not hasattr(self, '_draw_event_id'):
+        self.log.debug('attaching draw event')
+        self._draw_event_id = self.connect_after('draw', dock_group_draw_highlight)
     self.queue_draw()
 
 
@@ -643,8 +643,8 @@ def dock_unhighlight(self):
     self.queue_draw()
 
     try:
-        self.disconnect(self._expose_event_id)
-        del self._expose_event_id
+        self.disconnect(self._draw_event_id)
+        del self._draw_event_id
     except AttributeError as e:
         self.log.debug(e, exc_info=True)
 
@@ -724,7 +724,7 @@ def dock_group_drag_failed(self, context, result):
 ################################################################################
 # DockPaned
 ################################################################################
-def dock_paned_expose_highlight(self, event):
+def dock_paned_draw_highlight(self, da, ctx):
     try:
         handle = self._handles[self._drop_handle_index]
     except (AttributeError, IndexError, TypeError) as e:
@@ -733,18 +733,17 @@ def dock_paned_expose_highlight(self, event):
     else:
         a = handle.area
 
-    cr = self.window.cairo_create()
-    cr.set_source_rgb(0, 0, 0)
-    cr.set_line_width(1.0)
-    cr.rectangle(a.x + 0.5, a.y + 0.5, a.width - 1, a.height - 1)
-    cr.stroke()
+    ctx.set_source_rgb(0, 0, 0)
+    ctx.set_line_width(1.0)
+    ctx.rectangle(a.x + 0.5, a.y + 0.5, a.width - 1, a.height - 1)
+    ctx.stroke()
 
 
 def dock_paned_highlight(self):
-    if not hasattr(self, '_expose_event_id'):
-        self.log.debug('attaching expose event')
-        self._expose_event_id = self.connect_after('expose-event',
-                                                   dock_paned_expose_highlight)
+    if not hasattr(self, '_draw_event_id'):
+        self.log.debug('attaching draw event')
+        self._draw_event_id = self.connect_after('draw',
+                                                 dock_paned_draw_highlight)
     self.queue_draw()
 
 

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -969,7 +969,7 @@ def dock_frame_magic_borders(self, context, x, y, timestamp):
     placeholder.set_size_request(a.width, a.height)
     placeholder.show()
 
-    current_child = self.get_children()[0]
+    current_child = self.get_child()
     assert current_child
 
     if min(x - border, y - border) < MAGIC_BORDER_SIZE:

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -40,6 +40,7 @@ from .dockframe import DockFrame
 from .dockpaned import DockPaned
 from .dockgroup import DockGroup
 from .dockitem import DockItem
+from .docksettings import settings
 from .util import flatten
 from functools import reduce
 
@@ -943,7 +944,7 @@ def dock_frame_magic_borders(self, context, x, y, timestamp):
     "catch-all", the DockFrame.  The Frame should make sure a new DockPaned is
     created with the proper orientation and whatever's needed.
     '''
-    a = self.allocation
+    a = self.get_allocation()
     border = self.border_width
 
     if x - border < MAGIC_BORDER_SIZE:
@@ -966,7 +967,7 @@ def dock_frame_magic_borders(self, context, x, y, timestamp):
     placeholder = Placeholder()
 
     self.set_placeholder(placeholder)
-    placeholder.size_allocate(allocation)
+    placeholder.set_size_request(a.width, a.height)
     placeholder.show()
 
     current_child = self.get_children()[0]

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -438,7 +438,7 @@ def _window_delete_handler(window, event):
 
 
 def add_new_group_floating(new_group, layout, size=None, pos=None):
-    window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+    window = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
 
     if pos:
         window.move(*pos)

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -966,7 +966,7 @@ def dock_frame_magic_borders(self, context, x, y, timestamp):
     placeholder = Placeholder()
 
     self.set_placeholder(placeholder)
-    placeholder.set_size_request(a.width, a.height)
+    placeholder.size_allocate(allocation)
     placeholder.show()
 
     current_child = self.get_child()

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -399,7 +399,7 @@ def add_new_group(widget, new_group, orientation, position):
 
     try:
         current_position = parent.item_num(widget)
-        weight = parent.child_get_property(widget, 'weight')
+        weight = widget.get_property('weight')
     except AttributeError:
         current_position = None
 
@@ -796,7 +796,7 @@ def dock_paned_cleanup(self, layout):
 
         if isinstance(parent, DockPaned):
             position = [c for c in parent].index(self)
-            weight = parent.child_get_property(self, 'weight')
+            weight = self.get_property('weight')
             self.remove(child)
             parent.remove(self)
             parent.insert_item(child, position=position, weight=weight)
@@ -858,7 +858,7 @@ def dock_paned_magic_borders(self, context, x, y, timestamp):
             else:
                 orientation = Gtk.Orientation.HORIZONTAL
 
-            weight = self.child_get_property(current_group, 'weight')
+            weight = current_group.get_property('weight')
 
             if min(x, y) < MAGIC_BORDER_SIZE:
                 position = 0

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -276,7 +276,7 @@ class DockLayout(GObject.GObject):
             drag_data = self._drag_data
 
             if drag_data and drag_data.drop_widget:
-                target = Gdk.atom_intern(DRAG_TARGET_ITEM_LIST.target)
+                target = Gdk.atom_intern(atom_name=DRAG_TARGET_ITEM_LIST.target, only_if_exists=True)
                 drag_data.drop_widget.drag_get_data(context, target, timestamp)
                 return True
 

--- a/etkdocking/docklayout.py
+++ b/etkdocking/docklayout.py
@@ -26,21 +26,21 @@ import sys
 from collections import namedtuple
 from logging import getLogger
 
+import gi
 from simplegeneric import generic
 
-from gi.repository import GObject
-from gi.repository import Gtk
-import Gtk.gdk as gdk
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk, GObject
+
 import itertools
 from weakref import WeakKeyDictionary
 
 from .dnd import DRAG_TARGET_ITEM_LIST, Placeholder
-from etkdocking.dockframe import DockFrame
+from .dockframe import DockFrame
 from .dockpaned import DockPaned
 from .dockgroup import DockGroup
 from .dockitem import DockItem
 from .util import flatten
-from .docksettings import settings
 from functools import reduce
 
 # On OSX/X11 Utility windows are above all windows,

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -751,10 +751,19 @@ class DockPaned(Gtk.Container):
     def do_remove(self, widget):
         self._remove_item(widget)
 
-    def do_forall(self, internals, callback, data):
+    def do_forall(self, include_internals, callback, *callback_data):
+        """Invokes the given callback on each item, with the given data.
+
+        @param include_internals Whether to run on internal children as well, as
+                                 boolean. Ignored, as there are no internal
+                                 children.
+        @param callback The callback to call on each child, as Gtk.Callback
+        @param callback_data The parameters to pass to the callback, as object
+                             or None
+        """
         try:
             for item in self._items:
-                callback(item.get_child(), data)
+                callback(item.get_child(), *callback_data)
         except AttributeError:
             pass
 

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -582,7 +582,7 @@ class DockPaned(Gtk.Container):
                         if child is self._items[-1]:
                             rect.height += allocation.height - cy
 
-                    child.get_child().size_allocate(rect)
+                    child.child.size_allocate(rect)
 
                 elif isinstance(child, _DockPanedHandle):
                     if self._orientation == Gtk.Orientation.HORIZONTAL:

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -141,6 +141,7 @@ class DockPaned(Gtk.Container):
         # Initialize properties
         self.set_handle_size(4)
         self.set_orientation(Gtk.Orientation.HORIZONTAL)
+        self.set_weight(FALLBACK_WEIGHT)
 
     ############################################################################
     # Private
@@ -455,6 +456,8 @@ class DockPaned(Gtk.Container):
             self.set_handle_size(value)
         elif pspec.name == 'orientation':
             self.set_orientation(value)
+        elif pspec.name == 'weight':
+            self.set_weight(value)
 
     ############################################################################
     # GtkWidget
@@ -480,7 +483,7 @@ class DockPaned(Gtk.Container):
                      )
         self.window = Gdk.Window(self.get_parent_window(), attr, attr_mask)
         self.window.set_user_data(self)
-        self.set_window(self.window)
+        # self.set_window(self.window)
         self.set_realized(True)
 
         # Set parent window on all child widgets
@@ -650,7 +653,7 @@ class DockPaned(Gtk.Container):
 
         # Move/Resize our GdkWindow
         if self.get_realized():
-            self.window.move_resize(*allocation)
+            self.window.move_resize(x=allocation.x, y=allocation.y, width=allocation.width, height=allocation.height)
 
     def do_draw(self, cr):
         for item in self._items:
@@ -763,19 +766,6 @@ class DockPaned(Gtk.Container):
         except AttributeError:
             pass
 
-    def do_get_child_property(self, child, property_id, pspec):
-        item = self._item_for_child(child)
-
-        if pspec.name == 'weight':
-            return item.weight_request or item.weight
-
-    def do_set_child_property(self, child, property_id, value, pspec):
-        item = self._item_for_child(child)
-
-        if pspec.name == 'weight':
-            item.weight_request = value
-            child.child_notify('weight')
-
     ############################################################################
     # EtkDockPaned
     ############################################################################
@@ -814,6 +804,22 @@ class DockPaned(Gtk.Container):
         self._orientation = orientation
         self.notify('orientation')
         self.queue_resize()
+
+    def get_weight(self):
+        '''
+        :return: the weight of the dockpaned.
+
+        Retrieves the weight of the dockpaned.
+        '''
+        return self.weight
+
+    def set_weight(self, weight):
+        '''
+        :param weight: the dockpaned's new orientation.
+
+        Sets the weight of the dockpaned.
+        '''
+        self.weight = weight
 
     def append_item(self, child):
         '''

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -46,9 +46,9 @@ FALLBACK_WEIGHT = 0.2
 
 
 class _DockPanedHandle(object):
-    '''
+    """
     Private object storing information about a handle.
-    '''
+    """
     __slots__ = ['area']  # area, used for hit testing (Gdk.Rectangle)
 
     def __init__(self):
@@ -59,9 +59,9 @@ class _DockPanedHandle(object):
 
 
 class _DockPanedItem(object):
-    '''
-    Private object storing information about a child widget.
-    '''
+    """Private object storing information about a child widget.
+
+    """
     __slots__ = ['child',  # child widget
                  'weight',  # relative weight [0..1]
                  'weight_request',  # requested weight, processed in size_allocate()
@@ -77,17 +77,18 @@ class _DockPanedItem(object):
 
 
 class DockPaned(Gtk.Container):
-    '''
-    The :class:`etk.DockPaned` widget is a container widget with multiple panes
-    arranged either horizontally or vertically, depending on the value of the
-    orientation property. Child widgets are added to the panes of the widget
-    with the :meth:`append_item`, :meth:`prepend_item` or :meth:`insert_item`
-    methods.
+    """Container containing multiple horizontal or vertical panes.
 
-    A dockpaned widget draws a separator between it's child widgets and a small
-    handle that the user can drag to adjust the division. It does not draw any
-    relief around the children or around the separator.
-    '''
+    This widget is a container widget with multiple panes arranged either
+    horizontally or vertically, depending on the value of the orientation
+    property. Child widgets are added to the panes of the widget with the
+    append_item, prepend_item, or insert_item methods.
+
+    It draws a separator between its child widgets and a small handle that the
+    user can drag to adjust the division. It does not draw any relief around
+    the children or around the separator.
+
+    """
     __gtype_name__ = 'EtkDockPaned'
     __gproperties__ = \
         {'handle-size':
@@ -147,14 +148,16 @@ class DockPaned(Gtk.Container):
     # Private
     ############################################################################
     def _children(self):
-        '''
-        :returns: an iterator that returns the items and handles in the dockpaned.
+        """Yields an iterator of the items and handles in the DockPaned.
 
-        The :meth:`_children` method returns an iterator that returns the items
-        and handles in the dockpaned in the order they are drawn. This
-        corresponds to ``[_items[0], _handles[0], _items[1], _handles[1],
-        _items[2], ...]``
-        '''
+        Yields an iterator that returns the items and handles in the dockpaned
+        in the order they are drawn. This corresponds to [_items[0],
+        _handles[0], _items[1], _handles[1], _items[2], ...].
+
+        Yields:
+            object: The items and handles in the DockPaned
+
+        """
         index = 0
         switch = True
 
@@ -168,18 +171,23 @@ class DockPaned(Gtk.Container):
                 index += 1
 
     def _insert_item(self, child, position=None, weight=None):
-        '''
-        :param child: a :class:`Gtk.Widget` to use as the contents of the item.
-        :param position: the index (starting at 0) at which to insert the
-                         item, negative or :const:`None` to append the item
-                         after all other items.
-        :param weight: The relative amount of space the child should get. No guarantees.
-        :returns: the index number of the item in the dockpaned.
+        """Inserts an item in the DockPaned.
 
-        The :meth:`_insert_item` method is the private implementation behind
-        the :meth:`add`, :meth:`insert_item`, :meth:`append_item` and
-        :meth:`prepend_item` methods.
-        '''
+        The private implementation behind the `add`, `insert_item`,
+        `append_item`, and `prepend_item` methods.
+
+        Args:
+            child (Gtk.Widget): The child to use as the contents of the item.
+            position (int): The index (starting at 0) at which to insert the
+                item, negative or None to append the item after all the other
+                items.
+            weight (float): The relative amount of space the child should get,
+                no guarantees.
+
+        Returns:
+            int: The index number of the item in the DockPaned.
+
+        """
         assert isinstance(child, Gtk.Widget)
         assert self.item_num(child) is None
         assert not child.get_parent()
@@ -229,12 +237,15 @@ class DockPaned(Gtk.Container):
         return self.item_num(child)
 
     def _remove_item(self, child):
-        '''
-        :param child: a :class:`Gtk.Widget` to use as the contents of the item.
+        """Removes the child item from the DockPaned.
 
-        The :meth:`_remove_item` method is the private implementation behind
-        the :meth:`remove` and :meth:`remove_item` methods.
-        '''
+        The private implementation behind the `remove` and `remove_item`
+        methods.
+
+        Args:
+            child (Gtk.Widget): The child to use as the contents of the item.
+
+        """
         item_num = self.item_num(child)
         assert item_num is not None
 
@@ -254,22 +265,23 @@ class DockPaned(Gtk.Container):
         self.emit('item-removed', child)
 
     def _insert_handle(self, position):
-        '''
-        :param position: the index (starting at 0) at which to insert a handle.
+        """Insert a handle at the index specified by the position.
 
-        The :meth:`_insert_handle` inserts a handle at the index specified by
-        `position`.
-        '''
+        Args:
+            position (int): Index (starting at 0) of where to insert the
+                handle.
+
+        """
         handle = _DockPanedHandle()
         self._handles.insert(position, handle)
 
     def _remove_handle(self, position):
-        '''
-        :param position: the index (starting at 0) at which to remove a handle.
+        """Remove a handle at the index specified by the position.
 
-        The :meth:`_remove_handle` removes a handle at the index specified by
-        `position`.
-        '''
+            position (int): Index (starting at 0) of where to remove the
+                handle.
+
+        """
         try:
             # Remove the DockPanedHandle that used to be located after
             # the DockPanedItem we just removed
@@ -280,25 +292,26 @@ class DockPaned(Gtk.Container):
             # be located before the DockPanedItem we just removed
             del self._handles[position - 1]
 
-    def _get_n_handles(self):
-        '''
-        :returns: the number of handles in the dockpaned.
+    def _get_num_handles(self):
+        """Returns the number of handles in the DockPaned.
 
-        The :meth:`_get_n_handles` method returns the number of handles in the
-        dockpaned.
-        '''
+        Returns:
+            int: The number of handles.
+
+        """
         return len(self._handles)
 
     def _get_handle_at_pos(self, x, y):
-        '''
-        :param x: the x coordinate of the position.
-        :param y: the y coordinate of the position.
-        :returns: the handle at the position specified by x and y or :const:`None`.
+        """Returns the handle whose area contains the point.
 
-        The :meth:`_get_handle_at_pos` method returns the handle whose area
-        contains the position specified by `x` and `y` or :const:`None` if no
-        handle is at that position.
-        '''
+        Args:
+            x (int): The x position of the point.
+            y (int): The y position of the point.
+
+        Returns:
+            object: The handle, or None if there is no handle at that position.
+
+        """
         for handle in self._handles:
             if (x, y) in handle:
                 return handle
@@ -306,40 +319,62 @@ class DockPaned(Gtk.Container):
             return None
 
     def _item_for_child(self, child):
+        """Get the item associated with a child.
+
+        Args:
+            child: The child to look for as the child of an item.
+
+        Returns:
+            object: The item.
+
+        """
         for item in self._items:
             if item.child is child:
                 return item
         raise ValueError('child widget %s not in paned' % child)
 
     def _size(self, allocation):
-        '''
-        Get the size (width or height) required in calculations, depending on the
-        Paned's orientation.
-        '''
+        """Get the size (width or height), depending on the orientation.
+
+        Args:
+            allocation (Gdk.Rectangle): The rectangle to calculate the size
+                from.
+
+        Return:
+            size (int): The width or height.
+
+        """
         if self._orientation == Gtk.Orientation.HORIZONTAL:
             return allocation.width
         else:
             return allocation.height
 
     def _effective_size(self, allocation):
-        '''
-        Find the size we can actually spend on items.
-        '''
-        return self._size(allocation) - self._get_n_handles() * self._handle_size
+        """Find the size we can actually spend on items.
+
+        The effective size is the size based on the orientation minus the
+        size needed to be given to the handles.
+
+        Args:
+            allocation (Gdk.Rectangle): The rectangle to calculate the size
+                from.
+
+        """
+        return self._size(allocation) - self._get_num_handles() * self._handle_size
 
     def _redistribute_size(self, delta_size, enlarge, shrink):
-        '''
-        :param delta_size: the size we want to add the item specified by
-                           `enlarge`.
-        :param enlarge: the `_DockPanedItem` we want to add size to.
-        :param shrink: a list of `_DockPanedItem`'s where the size requested
-                       by `delta_size` will be removed.
+        """Shrink items and add the freed size to the enlarge item.
 
-        The :meth:`_redistribute_size` method subtracts size from the items
-        specified by `shrink` and adds the freed size to the item specified by
-        `enlarge`. This is done until `delta_size` reaches 0, or there's no
-        more items left in `shrink`.
-        '''
+        Subtracts size from the items specified by `shrink` and adds the freed
+        size to the item specified by `enlarge`. This is done until
+        `delta_size` reaches 0, or there's no more items left in `shrink`.
+
+        Args:
+            delta_size (int): The size to add to the enlarge item.
+            enlarge (_DockPanedItem): The item to add size to.
+            shrink (list): The list of `_DockPanedItem`'s to take size from.
+
+        """
         # Distribute delta_size amongst the items in shrink
         size = self._effective_size(self.allocation)
         enlarge_alloc = enlarge.child.allocation
@@ -369,18 +404,21 @@ class DockPaned(Gtk.Container):
         self.queue_resize()
 
     def _redistribute_weight(self, size):
-        '''
-        Divide the space available over the items. Items that have explicitly been
-        assigned a weight should get it assigned, as long as the max weight (1.0) is not
-        exeeded.
+        """Divide the space available over the items.
+
+        Items that have explicitly been assigned a weight should get it
+        assigned, as long as the max weight (1.0) is not exceeded.
 
         The general scheme is as follows:
-
         * figure out which items requested a new weight
         * ensure sum(min_sizes) fits in the allocated size
         * ensure the requested weights do not make items go smaller than min_size
         * divide remaining space over other items.
-        '''
+
+        Args:
+            size (float): The size to distribute.
+
+        """
         items = self._items
         size = float(size)
 
@@ -444,6 +482,15 @@ class DockPaned(Gtk.Container):
     # GObject
     ############################################################################
     def do_get_property(self, pspec):
+        """Gets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): A property of the DockPaned.
+
+        Returns:
+            The parameter value.
+
+        """
         if pspec.name == 'handle-size':
             return self.get_handle_size()
         elif pspec.name == 'orientation':
@@ -452,6 +499,13 @@ class DockPaned(Gtk.Container):
             return self.get_weight()
 
     def do_set_property(self, pspec, value):
+        """Sets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): A property of the DockPaned.
+            value: The value to set.
+
+        """
         if pspec.name == 'handle-size':
             self.set_handle_size(value)
         elif pspec.name == 'orientation':
@@ -463,6 +517,9 @@ class DockPaned(Gtk.Container):
     # GtkWidget
     ############################################################################
     def do_realize(self):
+        """Creates the Gdk window resources for the DockPaned.
+
+        """
         allocation = self.get_allocation()
         attr = Gdk.WindowAttr()
         attr.x = allocation.x
@@ -495,6 +552,9 @@ class DockPaned(Gtk.Container):
         self._vcursor = Gdk.Cursor.new_from_name(display=self.get_display(), name="ns-resize")
 
     def do_unrealize(self):
+        """Clears the Gdk window resources for the DockPaned.
+
+        """
         self._hcursor = None
         self._vcursor = None
         self.window.set_user_data(None)
@@ -502,26 +562,43 @@ class DockPaned(Gtk.Container):
         Gtk.Container.do_unrealize(self)
 
     def do_map(self):
+        """Causes the DockPaned to be mapped if it isn’t already.
+
+        """
         self.window.show()
         Gtk.Container.do_map(self)
 
     def do_unmap(self):
+        """Causes the DockPaned to be unmapped if it is mapped.
+
+        """
         self.window.hide()
         Gtk.Container.do_unmap(self)
 
     def do_get_request_mode(self):
-        """Returns whether the container prefers a height-for-width or a
+        """Returns teh preferred container layout.
+
+        Returns whether the container prefers a height-for-width or a
         width-for-height layout. DockPaned doesn't trade width for height or
         height for width so we return CONSTANT_SIZE.
+
+        Returns:
+            Gtk.SizeRequestMode: the constant size request mode.
+
         """
         return Gtk.SizeRequestMode.CONSTANT_SIZE
 
     def do_get_preferred_height(self):
-        """Calculates the container's initial minimum and natural height. While
-        this call is specific to width-for-height requests (that we requested
+        """Calculates the container's initial minimum and natural height.
+
+        While this call is specific to width-for-height requests (that we requested
         not to get) we cannot be certain that our wishes are granted, so
         we must implement this method as well. Returns the the decoration area
         height.
+
+        Returns:
+             int: minimum height, natural height.
+
         """
         min_height = nat_height = 0
 
@@ -534,17 +611,22 @@ class DockPaned(Gtk.Container):
             item.min_size = nat_height
 
         # Add handles
-        min_height += self._get_n_handles() * self._handle_size
-        nat_height += self._get_n_handles() * self._handle_size
+        min_height += self._get_num_handles() * self._handle_size
+        nat_height += self._get_num_handles() * self._handle_size
 
         return min_height, nat_height
 
     def do_get_preferred_width(self):
-        """Calculates the container's initial minimum and natural width. While
-        this call is specific to width-for-height requests (that we requested
-        not to get) we cannot be certain that our wishes are granted, so
-        we must implement this method as well. Returns the the decoration area
+        """Calculates the container's initial minimum and natural width.
+
+        While this call is specific to width-for-height requests (that we
+        requested not to get) we cannot be certain that our wishes are granted,
+        so we must implement this method as well. Returns the decoration area
         width.
+
+        Returns:
+            int: minimum width, natural width
+
         """
         # Start with nothing
         min_width = nat_width = 0
@@ -558,50 +640,66 @@ class DockPaned(Gtk.Container):
             item.min_size = item_nat
 
         # Add handles
-        min_width += self._get_n_handles() * self._handle_size
-        nat_width += self._get_n_handles() * self._handle_size
+        min_width += self._get_num_handles() * self._handle_size
+        nat_width += self._get_num_handles() * self._handle_size
 
         return min_width, nat_width
 
     def do_get_preferred_height_for_width(self, width):
-        """Returns this container's minimum and natural height if it would be
-        given the specified width. While this call is specific to
-        height-for-width requests (that we requested not to get) we cannot be
-        certain that our wishes are granted, so we must implement this method
-        as well. Since we really want to be the same size always, we simply
-        return do_get_preferred_height.
+        """If given width, returns the minimum and natural height.
 
-        @param width The given width, as int. Ignored.
+        Returns the container's minimum and natural height if given the
+        specified width. While this call is specific to height-for-width
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_height.
+
+        Args:
+            width (int): The given width. Ignored.
+
+        Returns:
+            int: minimum height, natural height
+
         """
         return self.do_get_preferred_height()
 
     def do_get_preferred_width_for_height(self, height):
-        """Returns this container's minimum and natural width if it would be
-        given the specified height. While this call is specific to
-        width-for-height requests (that we requested not to get) we cannot be
-        certain that our wishes are granted, so we must implement this method
-        as well. Since we really want to be the same size always, we simply
-        return do_get_preferred_width.
+        """If given height, returns the minimum and natural width.
 
-        @param height The given height, as int. Ignored.
+        Returns the container's minimum and natural width if given the
+        specified height. While this call is specific to width-for-height
+        requests (that we requested not to get) we cannot be certain that our
+        wishes are granted, so we must implement this method as well. Since we
+        really want to be the same size always, we simply return
+        do_get_preferred_width.
+
+        Args:
+            height (int): The given height. Ignored.
+
+        Returns:
+            int: minimum width, natural width.
+
         """
         return self.do_get_preferred_width()
 
     def do_size_allocate(self, allocation):
-        ####################################################################
-        # DockPaned resizing explained
-        #
-        # When a widget is resized (ie when the parent window is resized by
-        # the user), the do_size_request & do_size_allocate dance is
-        # typically executed multiple times with small changes (1 or 2 pixels,
-        # sometimes more depending on the gdk backend used), instead of one
-        # pass with the complete delta. Distributing those small values
-        # evenly across multiple child widgets simply doesn't work very well.
-        # To overcome this problem, we assign a weight (can be translated to
-        # "factor") to each child.
-        #
-        ####################################################################
+        """Assigns a size and position to the child widgets.
 
+        Children may adjust the given allocation in the adjust_size_allocation
+        virtual method. When a widget is resized (ie when the parent window is
+        resized by the user), the do_get_preferred_size & do_size_allocate
+        dance is typically executed multiple times with small changes (1 or 2
+        pixels, sometimes more depending on the gdk backend used), instead of
+        one pass with the complete delta. Distributing those small values
+        evenly across multiple child widgets simply doesn't work very well. To
+        overcome this problem, we assign a weight (can be translated to
+        "factor") to each child.
+
+        Args:
+            allocation (Gdk.Rectangle): Position and size allocated.
+
+        """
         if self._items:
             size = self._effective_size(allocation)
 
@@ -656,6 +754,16 @@ class DockPaned(Gtk.Container):
             self.window.move_resize(x=allocation.x, y=allocation.y, width=allocation.width, height=allocation.height)
 
     def do_draw(self, cr):
+        """Draws the container to the given Cairo context.
+
+        The top left corner of the widget will be drawn to the currently set
+        origin point of the context. The container needs to propagate the draw
+        signal to its children.
+
+        Args:
+            cr (cairo.Context): The Cairo context to draw into
+
+        """
         for item in self._items:
             self.propagate_draw(item.child, cr)
 
@@ -664,14 +772,34 @@ class DockPaned(Gtk.Container):
             pass
 
     def do_leave_notify_event(self, event):
+        """Called when the pointer has entered the widget.
+
+        Args:
+            event (Gdk.EventCrossing): The event that is generated when the pointer leaves.
+
+        Returns:
+            True.
+
+        """
         # Reset cursor
         self.window.set_cursor(None)
 
     def do_button_press_event(self, event):
-        # We might be starting a drag operation, or we could simply be starting
-        # a click somewhere. Store information from this event in self._dragcontext
-        # and decide in do_motion_notify_event if we're actually starting a
-        # drag operation or not.
+        """Called when a pointer button is pressed.
+
+        Sets the drag context source position and button equal to event if the
+        event window is the DockPaned window and the button. We might start a
+        DnD operation, or we could simply be starting a click on a tab. Store
+        information from this event in self.dragcontext and decide in
+        do_motion_notify_event if we're actually starting a DnD operation.
+
+        Args:
+            event (Gdk.EventButton): The event that triggered the signal
+
+        Returns:
+            bool: True to stop other handlers from being invoked for the event
+
+        """
         if event.window is self.window and event.button == 1:
             handle = self._get_handle_at_pos(event.x, event.y)
 
@@ -686,6 +814,20 @@ class DockPaned(Gtk.Container):
         return False
 
     def do_button_release_event(self, event):
+        """Called when a pointer button is released.
+
+        On pointer button release, check if the user clicked on a tab, or right
+        clicked to get a context menu. A special tab context menu is not
+        currently implemented for right clicks on a tab, but this could be a
+        potential enhancement in the future.
+
+        Args:
+            event (Gdk.EventButton): The event that triggered the signal
+
+        Returns:
+            bool: True to stop other handlers from being invoked for the event
+
+        """
         # Reset drag context
         if event.button == self._dragcontext.source_button:
             self._dragcontext.reset()
@@ -695,6 +837,19 @@ class DockPaned(Gtk.Container):
         return False
 
     def do_motion_notify_event(self, event):
+        """Called when the pointer moves over the DockPaned.
+
+        When the motion notify event happens over a DockPaned, check if a DnD
+        operation is in progress, and if so check if the user is dragging tabs
+        in the DockPaned.
+
+        Args:
+            event (Gdk.EventMotion): The event that triggered the signal
+
+        Returns:
+            bool: True to stop other handlers from being invoked for the event
+
+        """
         cursor = None
 
         # Set an appropriate cursor when the pointer is over a handle
@@ -745,20 +900,32 @@ class DockPaned(Gtk.Container):
     # GtkContainer
     ############################################################################
     def do_add(self, widget):
+        """Called when the given widget is added to the DockPaned.
+
+        Args:
+            widget (Gtk.Widget): The widget to add
+
+        """
         self._insert_item(widget)
 
     def do_remove(self, widget):
+        """Called when the given widget is removed from the DockPaned.
+
+        Args:
+            widget (Gtk.Widget): The widget to remove
+
+        """
         self._remove_item(widget)
 
     def do_forall(self, include_internals, callback, *callback_data):
         """Invokes the given callback on each item, with the given data.
 
-        @param include_internals Whether to run on internal children as well, as
-                                 boolean. Ignored, as there are no internal
-                                 children.
-        @param callback The callback to call on each child, as Gtk.Callback
-        @param callback_data The parameters to pass to the callback, as object
-                             or None
+        Args:
+            include_internals (bool): Run on internal children
+            callback (Gtk.Callback): The callback to call on each child
+            callback_data (object or None): The parameters to pass to the
+            callback
+
         """
         try:
             for item in self._items:
@@ -770,101 +937,123 @@ class DockPaned(Gtk.Container):
     # EtkDockPaned
     ############################################################################
     def get_handle_size(self):
-        '''
-        :return: the size of the handles in the dockpaned.
+        """Retrieves the size of the handles in the DockPaned.
 
-        Retrieves the size of the handles in the dockpaned.
-        '''
+        Returns:
+            int: The size of the handles in the DockPaned.
+
+        """
         return self._handle_size
 
     def set_handle_size(self, handle_size):
-        '''
-        :param handle_size: the new size for the handles in the dockpaned.
+        """Sets the size for the handles in the DockPaned.
 
-        Sets the size for the handles in the dockpaned.
-        '''
+        Args:
+            handle_size (int): The new size for the handles in the DockPaned.
+
+        """
         self._handle_size = handle_size
         self.notify('handle-size')
         self.queue_resize()
 
     def get_orientation(self):
-        '''
-        :return: the orientation of the dockpaned.
+        """Retrieves the orientation of the DockPaned.
 
-        Retrieves the orientation of the dockpaned.
-        '''
+        Returns:
+            Gtk.Orientation: The orientation of the DockPaned.
+
+        """
         return self._orientation
 
     def set_orientation(self, orientation):
-        '''
-        :param orientation: the dockpaned's new orientation.
+        """
+        :param orientation: the DockPaned's new orientation.
 
-        Sets the orientation of the dockpaned.
-        '''
+        Sets the orientation of the DockPaned.
+
+        Args:
+            orientation:
+        """
         self._orientation = orientation
         self.notify('orientation')
         self.queue_resize()
 
     def get_weight(self):
-        '''
-        :return: the weight of the dockpaned.
+        """Get the weight of the DockPaned.
 
-        Retrieves the weight of the dockpaned.
-        '''
+        Returns:
+            float: The weight
+
+        """
         return self.weight
 
     def set_weight(self, weight):
-        '''
-        :param weight: the dockpaned's new orientation.
+        """Set the weight of the DockPaned.
 
-        Sets the weight of the dockpaned.
-        '''
+        Args:
+            weight (float): The weight
+
+        Returns:
+            object:
+
+        """
         self.weight = weight
 
     def append_item(self, child):
-        '''
-        :param child: the :class:`Gtk.Widget` to use as the contents of the item.
-        :returns: the index number of the item in the dockpaned.
+        """Appends an item to the DockPaned.
 
-        The :meth:`append_item` method prepends an item to the dockpaned.
-        '''
+        Args:
+            child (Gtk.Widget): The item to append.
+
+        Returns:
+            int: The index number of the item in the DockPaned.
+
+        """
         return self._insert_item(child)
 
     def prepend_item(self, child):
-        '''
-        :param child: the :class:`Gtk.Widget` to use as the contents of the item.
-        :returns: the index number of the item in the dockpaned.
+        """Prepends an item to the DockPaned.
 
-        The :meth:`prepend_item` method prepends an item to the dockpaned.
-        '''
+        Args:
+            child (Gtk.Widget): The item to prepend.
+
+        Returns:
+            int: The index number of the item in the DockPaned.
+
+        """
         return self._insert_item(child, 0)
 
     def insert_item(self, child, position=None, weight=None):
-        '''
-        :param child: a :class:`Gtk.Widget`` to use as the contents of the item.
-        :param position: the index (starting at 0) at which to insert the item,
-                         negative or :const:`None` to append the item after all
-                         other items.
-        :param weight: The relative amount of space the child should get. No guarantees.
-        :returns: the index number of the item in the dockpaned.
+        """Insert an into the DockPaned.
 
-        The :meth:`insert_item` method inserts an item into the dockpaned at the
-        location specified by `position` (0 is the first item). `child` is the
-        widget to use as the contents of the item. If position is negative or
-        :const:`None` the item is appended to the dockpaned.
-        '''
+        Inserts an item into the DockPaned at the location specified by
+        position (0 is the first item). If position is None the item is
+        appended to the DockGroup.
+
+        Args:
+            child (Gtk.Widget): The widget to use as the contents of the item.
+            position (int): The index (0 start) at which to insert the item, or
+                None to append the item after all other item tabs.
+            weight (float): The relative amount of space the child should get.
+                No guarentees.
+
+        Returns:
+            int: The index number of the item in the DockPaned.
+
+        """
         return self._insert_item(child, position, weight)
 
     def remove_item(self, item_num):
-        '''
-        :param item_num: the index (starting from 0) of the item to remove. If
-                         :const:`None` or negative, the last item will be removed.
+        """Removes the item from the DockPaned.
 
-        The :meth:`remove_item` method removes the item at the location
-        specified by `item_num`. The value of `item_num` starts from 0. If
-        `item_num` is negative or :const:`None` the last item of the dockpaned
-        will be removed.
-        '''
+        Removes the item at the location specified by item_num. The value of
+        item_num starts from 0. If item_num is negative or None the last item
+        of the DockPaned will be removed.
+
+        Args:
+            item_num(int): The index (starting from 0) of the item to remove.
+
+        """
         if item_num is None or item_num < 0:
             child = self.get_nth_item(len(self) - 1)
         else:
@@ -873,46 +1062,56 @@ class DockPaned(Gtk.Container):
         self._remove_item(child)
 
     def item_num(self, child):
-        '''
-        :param child: a :class:`Gtk.Widget`.
-        :returns: the index of the item containing `child`, or :const:`None` if
-                  `child` is not in the dockpaned.
+        """Returns the index of the item which contains the child widget.
 
-        The :meth:`item_num()` method returns the index of the item which
-        contains the widget specified by `child` or :const:`None` if no item
-        contains `child`.
-        '''
+        Returns the index of the item which contains the widget specified by
+        child or None if no item contains the child.
+
+        Args:
+            child (Gtk.Widget): The child widget to get the index of.
+
+        Returns:
+            int: The index of the item containing the child.
+
+        """
         try:
             return self.get_children().index(child)
         except ValueError:
             pass
 
     def get_nth_item(self, item_num):
-        '''
-        :param item_num: the index of an item in the dockpaned.
-        :returns: the child widget, or :const:`None` if `item_num` is out of
-                  bounds.
+        """Gets the child widget contained at the index.
 
-        The :meth:`get_nth_item‘ method returns the child widget contained at
-        the index specified by `item_num`. If `item_num` is out of bounds for
-        the item range of the dockpaned this method returns :const:`None`.
-        '''
+        Returns the child widget contained at the index specified by item_num.
+        If item_num is out of bounds for the item range of the DockPaned,
+        returns None.
+
+        Args:
+            item_num (int): The index of an item in the DockPaned.
+
+        Returns:
+            Gtk.Widget: The child widget.
+
+        """
         if item_num >= 0 and item_num <= len(self) - 1:
             return self._items[item_num].child
         else:
             return None
 
     def get_item_at_pos(self, x, y):
-        '''
-        :param x: the x coordinate of the position.
-        :param y: the y coordinate of the position.
-        :returns: the child widget at the position specified by x and y or
-                  :const:`None`.
+        """Gets the child widget at the position.
 
-        The :meth:`get_item_at_pos` method returns the child widget whose
-        allocation contains the position specified by `x` and `y` or
-        :const:`None` if no child widget is at that position.
-        '''
+        Returns the child widget whose allocation contains the position
+        specified by x and y or, None if no child widget is at that position.
+
+        Args:
+            x (int): the x coordinate of the position.
+            y (int): the y coordinate of the position.
+
+        Returns:
+            Gtk.Widget the child widget at the position.
+
+        """
         for item in self._items:
             if (x, y) in item:
                 return item.child
@@ -920,17 +1119,18 @@ class DockPaned(Gtk.Container):
             return None
 
     def reorder_item(self, child, position):
-        '''
-        :param child: the child widget to move.
-        :param position: the index that `child` is to move to, or :const:`None` to
-                         move to the end.
+        """Reorders the DockPaned child widgets.
 
-        The :meth:`reorder_item` method reorders the dockpaned child widgets so
-        that `child` appears in the location specified by `position`. If
-        `position` is greater than or equal to the number of children in the
-        list or negative or :const:`None`, `child` will be moved to the end of
-        the list.
-        '''
+        Reorders the DockPaned child widgets so that the child appears in the
+        location specified by location. If position is greater than equal to
+        the number of children in the list or negative or None, child will be
+        moved to the end of the list.
+
+        Args:
+            child (Gtk.Widget): The child widget to move.
+            position (int): The index that the child is to move to.
+
+        """
         item_num = self.item_num(child)
         assert item_num is not None
 
@@ -944,11 +1144,11 @@ class DockPaned(Gtk.Container):
 
 
 def fair_scale(weight, wmpairs):
-    """
-    Fair scaling algorithm.
-    A weight and a list of (weight, min_weight) pairs is provided. The result is a list
-    of calculated weights that add up to weight, but are no smaller than their specified
-    min_weight's.
+    """Fair scaling algorithm.
+
+    A weight and a list of (weight, min_weight) pairs is provided. The result
+    is a list of calculated weights that add up to weight, but are no smaller
+    than their specified min_weight's.
 
     >>> fair_scale(.7, ((.3, .2), (.5, .1)))
     [0.26249999999999996, 0.43749999999999994]
@@ -956,6 +1156,14 @@ def fair_scale(weight, wmpairs):
     [0.2, 0.3]
     >>> fair_scale(.4, ((.3, .2), (.5, .1)))
     [0.2, 0.2]
+
+    Args:
+        weight (float): The relative amount of space the child should get.
+        wmpairs (list): List of (weight, min_weight) pairs.
+
+    Returns:
+        list: List of calculated weights.
+
     """
     # List of new weights
     n = [0] * len(wmpairs)

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -28,9 +28,10 @@ from builtins import zip
 from past.utils import old_div
 from logging import getLogger
 
-from gi.repository import GObject
-from gi.repository import Gtk
-import Gtk.gdk as gdk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk, GObject
 
 from .dnd import DockDragContext
 from .util import rect_overlaps

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -21,17 +21,21 @@
 
 from __future__ import absolute_import
 from __future__ import division
+
+from builtins import hex
 from builtins import object
 from builtins import range
-from builtins import hex
 from builtins import zip
-from past.utils import old_div
 from logging import getLogger
 
 import gi
+from past.utils import old_div
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk, GObject
+from gi.repository import Gdk
+from gi.repository import GLib
+from gi.repository import GObject
+from gi.repository import Gtk
 from gi import _propertyhelper as propertyhelper
 
 from .dnd import DockDragContext
@@ -92,9 +96,9 @@ class DockPaned(Gtk.Container):
               'handle size',
               'handle size',
               0,
-              GObject.G_MAXINT,
+              GLib.MAXINT,
               4,
-              GObject.PARAM_READWRITE),
+              GObject.ParamFlags.READWRITE),
          'orientation':
              (GObject.TYPE_UINT,
               'handle size',
@@ -102,7 +106,7 @@ class DockPaned(Gtk.Container):
               0,
               1,
               0,
-              GObject.PARAM_READWRITE)}
+              GObject.ParamFlags.READWRITE)}
     __gchild_properties__ = \
         {'weight':
              (GObject.TYPE_FLOAT,
@@ -111,7 +115,7 @@ class DockPaned(Gtk.Container):
               0,  # min
               1,  # max
               .2,  # default
-              GObject.PARAM_READWRITE)}
+              GObject.ParamFlags.READWRITE)}
     __gsignals__ = {'item-added':
                         (GObject.SignalFlags.RUN_LAST,
                          None,

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -28,9 +28,9 @@ from builtins import zip
 from past.utils import old_div
 from logging import getLogger
 
-import gobject
-import gtk
-import gtk.gdk as gdk
+from gi.repository import GObject
+from gi.repository import Gtk
+import Gtk.gdk as gdk
 
 from .dnd import DockDragContext
 from .util import rect_overlaps
@@ -44,10 +44,10 @@ class _DockPanedHandle(object):
     '''
     Private object storing information about a handle.
     '''
-    __slots__ = ['area']  # area, used for hit testing (gdk.Rectangle)
+    __slots__ = ['area']  # area, used for hit testing ()
 
     def __init__(self):
-        self.area = gdk.Rectangle()
+        self.area = ()
 
     def __contains__(self, pos):
         return rect_overlaps(self.area, *pos)
@@ -63,16 +63,16 @@ class _DockPanedItem(object):
                  'min_size']  # minimum relative weight
 
     def __init__(self):
-        self.child = None
+        self.get_child() = None
         self.weight = None
         self.weight_request = None
         self.min_size = None
 
     def __contains__(self, pos):
-        return rect_overlaps(self.child.allocation, *pos)
+        return rect_overlaps(self.get_child().allocation, *pos)
 
 
-class DockPaned(gtk.Container):
+class DockPaned(Gtk.Container):
     '''
     The :class:`etk.DockPaned` widget is a container widget with multiple panes
     arranged either horizontally or vertically, depending on the value of the
@@ -87,41 +87,41 @@ class DockPaned(gtk.Container):
     __gtype_name__ = 'EtkDockPaned'
     __gproperties__ = \
         {'handle-size':
-             (gobject.TYPE_UINT,
+             (GObject.TYPE_UINT,
               'handle size',
               'handle size',
               0,
-              gobject.G_MAXINT,
+              GObject.G_MAXINT,
               4,
-              gobject.PARAM_READWRITE),
+              GObject.PARAM_READWRITE),
          'orientation':
-             (gobject.TYPE_UINT,
+             (GObject.TYPE_UINT,
               'handle size',
               'handle size',
               0,
               1,
               0,
-              gobject.PARAM_READWRITE)}
+              GObject.PARAM_READWRITE)}
     __gchild_properties__ = \
         {'weight':
-             (gobject.TYPE_FLOAT,
+             (GObject.TYPE_FLOAT,
               'item weight',
               'item weight',
               0,  # min
               1,  # max
               .2,  # default
-              gobject.PARAM_READWRITE)}
+              GObject.PARAM_READWRITE)}
     __gsignals__ = {'item-added':
-                        (gobject.SIGNAL_RUN_LAST,
-                         gobject.TYPE_NONE,
-                         (gobject.TYPE_OBJECT,)),
+                        (GObject.SignalFlags.RUN_LAST,
+                         None,
+                         (GObject.TYPE_OBJECT,)),
                     'item-removed':
-                        (gobject.SIGNAL_RUN_LAST,
-                         gobject.TYPE_NONE,
-                         (gobject.TYPE_OBJECT,))}
+                        (GObject.SignalFlags.RUN_LAST,
+                         None,
+                         (GObject.TYPE_OBJECT,))}
 
     def __init__(self):
-        gtk.Container.__init__(self)
+        GObject.GObject.__init__(self)
 
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))
@@ -137,7 +137,7 @@ class DockPaned(gtk.Container):
 
         # Initialize properties
         self.set_handle_size(4)
-        self.set_orientation(gtk.ORIENTATION_HORIZONTAL)
+        self.set_orientation(Gtk.Orientation.HORIZONTAL)
 
     ############################################################################
     # Private
@@ -165,7 +165,7 @@ class DockPaned(gtk.Container):
 
     def _insert_item(self, child, position=None, weight=None):
         '''
-        :param child: a :class:`gtk.Widget` to use as the contents of the item.
+        :param child: a :class:`Gtk.Widget` to use as the contents of the item.
         :param position: the index (starting at 0) at which to insert the
                          item, negative or :const:`None` to append the item
                          after all other items.
@@ -176,7 +176,7 @@ class DockPaned(gtk.Container):
         the :meth:`add`, :meth:`insert_item`, :meth:`append_item` and
         :meth:`prepend_item` methods.
         '''
-        assert isinstance(child, gtk.Widget)
+        assert isinstance(child, Gtk.Widget)
         assert self.item_num(child) is None
         assert not child.get_parent()
 
@@ -185,11 +185,11 @@ class DockPaned(gtk.Container):
 
         # Create new _DockPanedItem
         item = _DockPanedItem()
-        item.child = child
-        item.child.set_parent(self)
+        item.get_child() = child
+        item.get_child().set_parent(self)
 
-        if self.flags() & gtk.REALIZED:
-            item.child.set_parent_window(self.window)
+        if self.get_realized():
+            item.get_child().set_parent_window(self.window)
 
         self._items.insert(position, item)
 
@@ -207,7 +207,7 @@ class DockPaned(gtk.Container):
             item.weight = 1.0
         elif self.allocation and child.allocation:
             size = self._effective_size(self.allocation) - self._handle_size
-            if self._orientation == gtk.ORIENTATION_HORIZONTAL:
+            if self._orientation == Gtk.Orientation.HORIZONTAL:
                 child_size = child.size_request()[0]
             else:
                 child_size = child.size_request()[1]
@@ -225,7 +225,7 @@ class DockPaned(gtk.Container):
 
     def _remove_item(self, child):
         '''
-        :param child: a :class:`gtk.Widget` to use as the contents of the item.
+        :param child: a :class:`Gtk.Widget` to use as the contents of the item.
 
         The :meth:`_remove_item` method is the private implementation behind
         the :meth:`remove` and :meth:`remove_item` methods.
@@ -302,7 +302,7 @@ class DockPaned(gtk.Container):
 
     def _item_for_child(self, child):
         for item in self._items:
-            if item.child is child:
+            if item.get_child() is child:
                 return item
         raise ValueError('child widget %s not in paned' % child)
 
@@ -311,7 +311,7 @@ class DockPaned(gtk.Container):
         Get the size (width or height) required in calculations, depending on the
         Paned's orientation.
         '''
-        if self._orientation == gtk.ORIENTATION_HORIZONTAL:
+        if self._orientation == Gtk.Orientation.HORIZONTAL:
             return allocation.width
         else:
             return allocation.height
@@ -337,15 +337,15 @@ class DockPaned(gtk.Container):
         '''
         # Distribute delta_size amongst the items in shrink
         size = self._effective_size(self.allocation)
-        enlarge_alloc = enlarge.child.allocation
+        enlarge_alloc = enlarge.get_child().allocation
 
         for item in shrink:
 
-            available_size = self._size(item.child.allocation) - item.min_size
+            available_size = self._size(item.get_child().allocation) - item.min_size
 
             # Check if we can shrink (respecting the child's size_request)
             if available_size > 0:
-                a = item.child.allocation
+                a = item.get_child().allocation
 
                 # Can we adjust the whole delta or not?
                 if delta_size > available_size:
@@ -384,7 +384,7 @@ class DockPaned(gtk.Container):
             f = old_div(self._effective_size(self.allocation), size)
             for i in self._items:
                 # if i.weight and not i.expand and not i.weight_request:
-                if i.weight and not settings[i.child].expand and not i.weight_request:
+                if i.weight and not settings[i.get_child()].expand and not i.weight_request:
                     i.weight_request = i.weight * f
 
         requested_items = [i for i in items if i.weight_request]
@@ -415,7 +415,7 @@ class DockPaned(gtk.Container):
     ############################################################################
 
     def __getitem__(self, index):
-        return self._items[index].child
+        return self._items[index].get_child()
 
     def __delitem__(self, index):
         child = self[index]
@@ -426,13 +426,13 @@ class DockPaned(gtk.Container):
 
     def __contains__(self, child):
         for i in self._items:
-            if i.child is child:
+            if i.get_child() is child:
                 return True
         return False
 
     def __iter__(self):
         for i in self._items:
-            yield i.child
+            yield i.get_child()
 
     ############################################################################
     # GObject
@@ -454,45 +454,45 @@ class DockPaned(gtk.Container):
     ############################################################################
     def do_realize(self):
         # Internal housekeeping
-        self.set_flags(self.flags() | gtk.REALIZED)
-        self.window = gdk.Window(self.get_parent_window(),
+        self.set_flags(self.flags() | Gtk.REALIZED)
+        self.window = Gdk.Window(self.get_parent_window(),
                                  x=self.allocation.x,
                                  y=self.allocation.y,
                                  width=self.allocation.width,
                                  height=self.allocation.height,
-                                 window_type=gdk.WINDOW_CHILD,
-                                 wclass=gdk.INPUT_OUTPUT,
-                                 event_mask=(gdk.EXPOSURE_MASK |
-                                             gdk.LEAVE_NOTIFY_MASK |
-                                             gdk.BUTTON_PRESS_MASK |
-                                             gdk.BUTTON_RELEASE_MASK |
-                                             gdk.POINTER_MOTION_MASK))
+                                 window_type=Gdk.WINDOW_CHILD,
+                                 wclass=Gdk.INPUT_OUTPUT,
+                                 event_mask=(Gdk.EventMask.EXPOSURE_MASK |
+                                             Gdk.EventMask.LEAVE_NOTIFY_MASK |
+                                             Gdk.EventMask.BUTTON_PRESS_MASK |
+                                             Gdk.EventMask.BUTTON_RELEASE_MASK |
+                                             Gdk.EventMask.POINTER_MOTION_MASK))
         self.window.set_user_data(self)
         self.style.attach(self.window)
-        self.style.set_background(self.window, gtk.STATE_NORMAL)
+        self.style.set_background(self.window, Gtk.StateType.NORMAL)
 
         # Set parent window on all child widgets
         for item in self._items:
-            item.child.set_parent_window(self.window)
+            item.get_child().set_parent_window(self.window)
 
         # Initialize cursors
-        self._hcursor = gdk.Cursor(self.get_display(), gdk.SB_H_DOUBLE_ARROW)
-        self._vcursor = gdk.Cursor(self.get_display(), gdk.SB_V_DOUBLE_ARROW)
+        self._hcursor = Gdk.Cursor.new(self.get_display(), Gdk.SB_H_DOUBLE_ARROW)
+        self._vcursor = Gdk.Cursor.new(self.get_display(), Gdk.SB_V_DOUBLE_ARROW)
 
     def do_unrealize(self):
         self._hcursor = None
         self._vcursor = None
         self.window.set_user_data(None)
         self.window.destroy()
-        gtk.Container.do_unrealize(self)
+        Gtk.Container.do_unrealize(self)
 
     def do_map(self):
         self.window.show()
-        gtk.Container.do_map(self)
+        Gtk.Container.do_map(self)
 
     def do_unmap(self):
         self.window.hide()
-        gtk.Container.do_unmap(self)
+        Gtk.Container.do_unmap(self)
 
     def do_size_request(self, requisition):
         # Start with nothing
@@ -500,9 +500,9 @@ class DockPaned(gtk.Container):
 
         # Add child widgets
         for item in self._items:
-            w, h = item.child.size_request()
+            w, h = item.get_child().size_request()
 
-            if self._orientation == gtk.ORIENTATION_HORIZONTAL:
+            if self._orientation == Gtk.Orientation.HORIZONTAL:
                 width += w
                 height = max(height, h)
                 # Store the minimum weight for usage in do_size_allocate
@@ -514,7 +514,7 @@ class DockPaned(gtk.Container):
                 item.min_size = h
 
         # Add handles
-        if self._orientation == gtk.ORIENTATION_HORIZONTAL:
+        if self._orientation == Gtk.Orientation.HORIZONTAL:
             width += self._get_n_handles() * self._handle_size
         else:
             height += self._get_n_handles() * self._handle_size
@@ -548,14 +548,14 @@ class DockPaned(gtk.Container):
 
             # Allocate child widgets: both items and handles, so we can simply increment
             for child in self._children():
-                rect = gdk.Rectangle()
+                rect = ()
                 rect.x = cx
                 rect.y = cy
 
                 if isinstance(child, _DockPanedItem):
                     s = round(child.weight * size)
 
-                    if self._orientation == gtk.ORIENTATION_HORIZONTAL:
+                    if self._orientation == Gtk.Orientation.HORIZONTAL:
                         rect.height = allocation.height
                         rect.width = s
                         cx += s
@@ -570,10 +570,10 @@ class DockPaned(gtk.Container):
                         if child is self._items[-1]:
                             rect.height += allocation.height - cy
 
-                    child.child.size_allocate(rect)
+                    child.get_child().size_allocate(rect)
 
                 elif isinstance(child, _DockPanedHandle):
-                    if self._orientation == gtk.ORIENTATION_HORIZONTAL:
+                    if self._orientation == Gtk.Orientation.HORIZONTAL:
                         rect.height = allocation.height
                         rect.width = handle_size
                         cx += handle_size
@@ -588,12 +588,12 @@ class DockPaned(gtk.Container):
         self.allocation = allocation
 
         # Move/Resize our GdkWindow
-        if self.flags() & gtk.REALIZED:
+        if self.get_realized():
             self.window.move_resize(*allocation)
 
     def do_expose_event(self, event):
         for item in self._items:
-            self.propagate_expose(item.child, event)
+            self.propagate_expose(item.get_child(), event)
 
         for handle in self._handles:
             # TODO: render themed handle if not using compact layout
@@ -637,14 +637,14 @@ class DockPaned(gtk.Container):
 
         # Set an appropriate cursor when the pointer is over a handle
         if self._get_handle_at_pos(event.x, event.y):
-            if self._orientation == gtk.ORIENTATION_HORIZONTAL:
+            if self._orientation == Gtk.Orientation.HORIZONTAL:
                 cursor = self._hcursor
             else:
                 cursor = self._vcursor
 
         # Drag a handle
         if self._dragcontext.dragging:
-            if self._orientation == gtk.ORIENTATION_HORIZONTAL:
+            if self._orientation == Gtk.Orientation.HORIZONTAL:
                 cursor = self._hcursor
                 delta_size = int(event.x -
                                  self._dragcontext.dragged_object.area.x -
@@ -691,7 +691,7 @@ class DockPaned(gtk.Container):
     def do_forall(self, internals, callback, data):
         try:
             for item in self._items:
-                callback(item.child, data)
+                callback(item.get_child(), data)
         except AttributeError:
             pass
 
@@ -749,7 +749,7 @@ class DockPaned(gtk.Container):
 
     def append_item(self, child):
         '''
-        :param child: the :class:`gtk.Widget` to use as the contents of the item.
+        :param child: the :class:`Gtk.Widget` to use as the contents of the item.
         :returns: the index number of the item in the dockpaned.
 
         The :meth:`append_item` method prepends an item to the dockpaned.
@@ -758,7 +758,7 @@ class DockPaned(gtk.Container):
 
     def prepend_item(self, child):
         '''
-        :param child: the :class:`gtk.Widget` to use as the contents of the item.
+        :param child: the :class:`Gtk.Widget` to use as the contents of the item.
         :returns: the index number of the item in the dockpaned.
 
         The :meth:`prepend_item` method prepends an item to the dockpaned.
@@ -767,7 +767,7 @@ class DockPaned(gtk.Container):
 
     def insert_item(self, child, position=None, weight=None):
         '''
-        :param child: a :class:`gtk.Widget`` to use as the contents of the item.
+        :param child: a :class:`Gtk.Widget`` to use as the contents of the item.
         :param position: the index (starting at 0) at which to insert the item,
                          negative or :const:`None` to append the item after all
                          other items.
@@ -800,7 +800,7 @@ class DockPaned(gtk.Container):
 
     def item_num(self, child):
         '''
-        :param child: a :class:`gtk.Widget`.
+        :param child: a :class:`Gtk.Widget`.
         :returns: the index of the item containing `child`, or :const:`None` if
                   `child` is not in the dockpaned.
 
@@ -824,7 +824,7 @@ class DockPaned(gtk.Container):
         the item range of the dockpaned this method returns :const:`None`.
         '''
         if item_num >= 0 and item_num <= len(self) - 1:
-            return self._items[item_num].child
+            return self._items[item_num].get_child()
         else:
             return None
 
@@ -841,7 +841,7 @@ class DockPaned(gtk.Container):
         '''
         for item in self._items:
             if (x, y) in item:
-                return item.child
+                return item.get_child()
         else:
             return None
 

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -49,10 +49,10 @@ class _DockPanedHandle(object):
     '''
     Private object storing information about a handle.
     '''
-    __slots__ = ['area']  # area, used for hit testing ()
+    __slots__ = ['area']  # area, used for hit testing (Gdk.Rectangle)
 
     def __init__(self):
-        self.area = ()
+        self.area = Gdk.Rectangle()
 
     def __contains__(self, pos):
         return rect_overlaps(self.area, *pos)
@@ -559,7 +559,7 @@ class DockPaned(Gtk.Container):
 
             # Allocate child widgets: both items and handles, so we can simply increment
             for child in self._children():
-                rect = ()
+                rect = Gdk.Rectangle()
                 rect.x = cx
                 rect.y = cy
                 child.weight = self.get_property('weight')

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -32,6 +32,7 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GObject
+from gi import _propertyhelper as propertyhelper
 
 from .dnd import DockDragContext
 from .util import rect_overlaps
@@ -84,7 +85,7 @@ class DockPaned(Gtk.Container):
     handle that the user can drag to adjust the division. It does not draw any
     relief around the children or around the separator.
     '''
-    __gtype_name__ = 'EtkDockPaned'
+    # __gtype_name__ = 'EtkDockPaned'
     __gproperties__ = \
         {'handle-size':
              (GObject.TYPE_UINT,
@@ -121,7 +122,7 @@ class DockPaned(Gtk.Container):
                          (GObject.TYPE_OBJECT,))}
 
     def __init__(self):
-        GObject.GObject.__init__(self)
+        Gtk.Container.__init__(self)
 
         # Initialize logging
         self.log = getLogger('%s.%s' % (self.__gtype_name__, hex(id(self))))

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -712,7 +712,7 @@ class DockPaned(Gtk.Container):
         """
         try:
             for item in self._items:
-                callback(item.get_child(), *callback_data)
+                callback(item.child, *callback_data)
         except AttributeError:
             pass
 

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -913,7 +913,7 @@ class DockPaned(Gtk.Container):
         '''
         for item in self._items:
             if (x, y) in item:
-                return item.get_child()
+                return item.child
         else:
             return None
 

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -64,7 +64,6 @@ class _DockPanedItem(object):
                  'min_size']  # minimum relative weight
 
     def __init__(self):
-        self.get_child() = None
         self.weight = None
         self.weight_request = None
         self.min_size = None
@@ -186,8 +185,8 @@ class DockPaned(Gtk.Container):
 
         # Create new _DockPanedItem
         item = _DockPanedItem()
-        item.get_child() = child
-        item.get_child().set_parent(self)
+        item.child = child
+        item.child.set_parent(self)
 
         if self.get_realized():
             item.get_child().set_parent_window(self.window)

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -401,7 +401,7 @@ class DockPaned(Gtk.Container):
 
         if min_size > size:
             sf = old_div(size, min_size)
-            self.log.warn('Size scaling required (factor=%f)' % sf)
+            self.log.warning('Size scaling required (factor=%f)' % sf)
         else:
             sf = 1.0
 

--- a/etkdocking/dockpaned.py
+++ b/etkdocking/dockpaned.py
@@ -342,15 +342,15 @@ class DockPaned(Gtk.Container):
         '''
         # Distribute delta_size amongst the items in shrink
         size = self._effective_size(self.allocation)
-        enlarge_alloc = enlarge.get_child().allocation
+        enlarge_alloc = enlarge.child.allocation
 
         for item in shrink:
 
-            available_size = self._size(item.get_child().allocation) - item.min_size
+            available_size = self._size(item.child.allocation) - item.min_size
 
             # Check if we can shrink (respecting the child's size_request)
             if available_size > 0:
-                a = item.get_child().allocation
+                a = item.child.allocation
 
                 # Can we adjust the whole delta or not?
                 if delta_size > available_size:

--- a/etkdocking/docksettings.py
+++ b/etkdocking/docksettings.py
@@ -27,7 +27,7 @@ name can be used.
 
 from builtins import object
 from builtins import str
-import gtk
+from gi.repository import Gtk
 
 
 class DockSettings(object):
@@ -73,7 +73,7 @@ class DockSettingsDict(object):
         return self[target]
 
     def widget_name(self, target):
-        if isinstance(target, gtk.Widget):
+        if isinstance(target, Gtk.Widget):
             return target.get_name()
         return str(target)
 

--- a/etkdocking/docksettings.py
+++ b/etkdocking/docksettings.py
@@ -27,6 +27,9 @@ name can be used.
 
 from builtins import object
 from builtins import str
+import gi
+
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 

--- a/etkdocking/docksettings.py
+++ b/etkdocking/docksettings.py
@@ -34,16 +34,16 @@ from gi.repository import Gtk
 
 
 class DockSettings(object):
-    '''
-    Container for group specific settings.
-    The following settings can be set:
+    """Container for group specific settings.
 
+    The following settings can be set:
     * auto_remove: group is removed if if empty.
     * can_float: Group can be a floating group.
     * expand: A group can expand/shrink on resize.
-    * inherit_settings: new groups constructed from items dragged from a group should
-    get the same group name.
-    '''
+    * inherit_settings: new groups constructed from items dragged from a group
+        should get the same group name.
+
+    """
     __slots__ = ['auto_remove',
                  'can_float',
                  'float_retain_size',
@@ -60,14 +60,14 @@ class DockSettings(object):
 
 
 class DockSettingsDict(object):
-    '''
-    Settings container. Adheres partly to the dict protocol, only get() and setitem are
-    supported.
+    """Settings container.
 
-    Settings can deal with widget names as well as widgets itself (in which case the
-    name is requested). By overriding ``widget_name()`` it is possible to customize
-    the behaviour for settings.
-    '''
+    Adheres partly to the dict protocol, only get() and setitem are supported.
+    Settings can deal with widget names as well as widgets itself (in which
+    case the name is requested). By overriding ``widget_name()`` it is possible
+    to customize the behaviour for settings.
+
+    """
 
     def __init__(self):
         self._settings = {}  # Map group-id -> layout settings

--- a/etkdocking/dockstore.py
+++ b/etkdocking/dockstore.py
@@ -245,7 +245,7 @@ def dock_frame_factory(parent, width, height, floating=None, x=None, y=None):
     parent.add(frame)
 
     if floating == 'true':
-        window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        window = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         # self.set_type_hint(Gdk.WindowTypeHint.UTILITY)
         window.set_property('skip-taskbar-hint', True)
         window.move(int(x), int(y))

--- a/etkdocking/dockstore.py
+++ b/etkdocking/dockstore.py
@@ -22,7 +22,7 @@
 from __future__ import absolute_import
 from __future__ import division
 # TODO make parsing XML backwards compatible
-# from builtins import str
+#   from builtins import str
 from builtins import map
 from past.utils import old_div
 import sys
@@ -44,6 +44,15 @@ SERIALIZABLE = (DockFrame, DockPaned, DockGroup, DockItem)
 
 
 def serialize(layout):
+    """Serialize the DockLayout for saving to disk.
+
+    Args:
+        layout (DockLayout): The layout to serialize
+
+    Returns:
+        string: The serialized DockLayout.
+
+    """
     def _ser(widget, element):
         if isinstance(widget, SERIALIZABLE):
             sub = SubElement(element, type(widget).__name__.lower(), attributes(widget))
@@ -61,11 +70,20 @@ widget_factory = {}
 
 
 def deserialize(layoutstr, itemfactory):
-    '''
-    Return a new layout with it's attached frames. Frames that should be floating
-    already have their Gtk.Window attached (check frame.get_parent()). Transient settings
-    and such should be done by the invoking application.
-    '''
+    """Deserialize the DockLayout for loading from disk.
+
+    Returns a new layout with it's attached frames. Frames that should be
+    floating already have their Gtk.Window attached (check frame.get_parent()).
+    Transient settings and such should be done by the invoking application.
+
+    Args:
+        layoutstr (string): The serialized DockLayout to deserialize.
+        itemfactory (ItemFactory): The item factory for creating the layout.
+
+    Returns:
+        DockLayout: The deserialized layout.
+
+    """
 
     def _des(element, parent_widget=None):
         if element.tag == 'widget':
@@ -89,15 +107,30 @@ def deserialize(layoutstr, itemfactory):
 
 
 def get_main_frames(layout):
+    """Get the frames that are non-floating (the main frames).
+
+    Args:
+        layout (DockLayout): The layout to get the main frames for.
+
+    Returns:
+        tuple: The frames that are non-floating.
+
+    """
     return (f for f in layout.frames \
             if not isinstance(f.get_parent(), Gtk.Window))
 
 
 def finish(layout, main_frame):
-    '''
-    Finish the loading process by setting all floating windows "transient_for" the main
-    window (which should be a ancestor of the main_frame).
-    '''
+    """Finish the loading process of the layout using the main frame.
+
+    Sets all floating windows "transient_for" the main window (which should be
+    a ancestor of the main_frame).
+
+    Args:
+        layout (DockLayout): The layout to finish the loading process of.
+        main_frame: The main frame to use.
+
+    """
     main_window = main_frame.get_toplevel()
 
     for frame in layout.frames:
@@ -112,8 +145,14 @@ def finish(layout, main_frame):
 
 
 def parent_attributes(widget):
-    """
-    Add properties defined in the parent widget specific for this instance (like weight).
+    """Add properties to the widget from the parent.
+
+    Properties are defined in the parent widget specific for this instance
+    (like weight).
+
+    Args:
+        widget (Gtk.Widget): The widget to add properties to.
+
     """
     container = widget.get_parent()
     d = {}
@@ -176,10 +215,12 @@ def dock_frame_attributes(widget):
 
 
 def factory(typename):
-    '''
-    Simple decorator for populating the widget_factory dictionary.
-    '''
+    """Simple decorator for populating the widget_factory dictionary.
 
+    Args:
+        typename: The item type.
+
+    """
     def _factory(func):
         widget_factory[typename] = func
         return func
@@ -190,6 +231,9 @@ def factory(typename):
 @factory('dockitem')
 def dock_item_factory(parent, title, tooltip, icon_name=None, stock_id=None, pos=None, vispos=None, current=None,
                       name=None):
+    """The factory for creating a DockItem.
+
+    """
     item = DockItem(title, tooltip, icon_name, stock_id)
     if name:
         item.set_name(name)
@@ -203,6 +247,9 @@ def dock_item_factory(parent, title, tooltip, icon_name=None, stock_id=None, pos
 
 @factory('dockgroup')
 def dock_group_factory(parent, weight=None, name=None):
+    """The factory for creating a DockGroup.
+
+    """
     group = DockGroup()
 
     if name:
@@ -218,6 +265,9 @@ def dock_group_factory(parent, weight=None, name=None):
 
 @factory('dockpaned')
 def dock_paned_factory(parent, orientation, weight=None, name=None):
+    """The factory for creating a DockPaned.
+
+    """
     paned = DockPaned()
 
     if name:
@@ -238,6 +288,9 @@ def dock_paned_factory(parent, orientation, weight=None, name=None):
 
 @factory('dockframe')
 def dock_frame_factory(parent, width, height, floating=None, x=None, y=None):
+    """The factory for creating a DockFrame.
+
+    """
     assert isinstance(parent, DockLayout), parent
 
     frame = DockFrame()

--- a/etkdocking/dockstore.py
+++ b/etkdocking/dockstore.py
@@ -30,7 +30,7 @@ import sys
 from simplegeneric import generic
 from xml.etree.ElementTree import Element, SubElement, tostring, fromstring
 
-import gtk
+from gi.repository import Gtk
 
 from .docklayout import DockLayout
 from etkdocking.dockframe import DockFrame
@@ -61,7 +61,7 @@ widget_factory = {}
 def deserialize(layoutstr, itemfactory):
     '''
     Return a new layout with it's attached frames. Frames that should be floating
-    already have their gtk.Window attached (check frame.get_parent()). Transient settings
+    already have their Gtk.Window attached (check frame.get_parent()). Transient settings
     and such should be done by the invoking application.
     '''
 
@@ -88,7 +88,7 @@ def deserialize(layoutstr, itemfactory):
 
 def get_main_frames(layout):
     return (f for f in layout.frames \
-            if not isinstance(f.get_parent(), gtk.Window))
+            if not isinstance(f.get_parent(), Gtk.Window))
 
 
 def finish(layout, main_frame):
@@ -105,7 +105,7 @@ def finish(layout, main_frame):
         parent = frame.get_parent()
 
         if parent:
-            assert isinstance(parent, gtk.Window), parent
+            assert isinstance(parent, Gtk.Window), parent
             parent.set_transient_for(main_window)
 
 
@@ -117,7 +117,7 @@ def parent_attributes(widget):
     d = {}
 
     if isinstance(container, DockPaned):
-        paned_item = [i for i in container._items if i.child is widget][0]
+        paned_item = [i for i in container._items if i.get_child() is widget][0]
         if paned_item.weight:
             d['weight'] = str(int(paned_item.weight * 100))
 
@@ -129,7 +129,7 @@ def attributes(widget):
     raise NotImplementedError
 
 
-@attributes.when_type(gtk.Widget)
+@attributes.when_type(Gtk.Widget)
 def widget_attributes(widget):
     return {'name': widget.get_name() or 'empty'}
 
@@ -156,7 +156,7 @@ def dock_group_attributes(widget):
 
 @attributes.when_type(DockPaned)
 def dock_paned_attributes(widget):
-    return dict(orientation=(widget.get_orientation() == gtk.ORIENTATION_HORIZONTAL and 'horizontal' or 'vertical'),
+    return dict(orientation=(widget.get_orientation() == Gtk.Orientation.HORIZONTAL and 'horizontal' or 'vertical'),
                 **parent_attributes(widget))
 
 
@@ -166,7 +166,7 @@ def dock_frame_attributes(widget):
     d = dict(width=str(a.width), height=str(a.height))
     parent = widget.get_parent()
 
-    if isinstance(parent, gtk.Window) and parent.get_transient_for():
+    if isinstance(parent, Gtk.Window) and parent.get_transient_for():
         d['floating'] = 'true'
         d['x'], d['y'] = list(map(str, parent.get_position()))
 
@@ -222,9 +222,9 @@ def dock_paned_factory(parent, orientation, weight=None, name=None):
         paned.set_name(name)
 
     if orientation == 'horizontal':
-        paned.set_orientation(gtk.ORIENTATION_HORIZONTAL)
+        paned.set_orientation(Gtk.Orientation.HORIZONTAL)
     else:
-        paned.set_orientation(gtk.ORIENTATION_VERTICAL)
+        paned.set_orientation(Gtk.Orientation.VERTICAL)
 
     if weight is not None:
         item = parent.insert_item(paned, weight=old_div(float(weight), 100.))
@@ -243,8 +243,8 @@ def dock_frame_factory(parent, width, height, floating=None, x=None, y=None):
     parent.add(frame)
 
     if floating == 'true':
-        window = gtk.Window(gtk.WINDOW_TOPLEVEL)
-        # self.window.set_type_hint(gdk.WINDOW_TYPE_HINT_UTILITY)
+        window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        # self.set_type_hint(Gdk.WindowTypeHint.UTILITY)
         window.set_property('skip-taskbar-hint', True)
         window.move(int(x), int(y))
         window.add(frame)

--- a/etkdocking/dockstore.py
+++ b/etkdocking/dockstore.py
@@ -54,7 +54,7 @@ def serialize(layout):
     tree = Element('layout')
     list(map(_ser, layout.frames, [tree] * len(layout.frames)))
 
-    return tostring(tree, encoding=sys.getdefaultencoding())
+    return tostring(tree, encoding="utf-8")
 
 
 widget_factory = {}

--- a/etkdocking/dockstore.py
+++ b/etkdocking/dockstore.py
@@ -164,7 +164,7 @@ def dock_paned_attributes(widget):
 
 @attributes.when_type(DockFrame)
 def dock_frame_attributes(widget):
-    a = widget.allocation
+    a = widget.get_allocation()
     d = dict(width=str(a.width), height=str(a.height))
     parent = widget.get_parent()
 

--- a/etkdocking/dockstore.py
+++ b/etkdocking/dockstore.py
@@ -27,13 +27,15 @@ from builtins import map
 from past.utils import old_div
 import sys
 
+import gi
 from simplegeneric import generic
 from xml.etree.ElementTree import Element, SubElement, tostring, fromstring
 
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from .docklayout import DockLayout
-from etkdocking.dockframe import DockFrame
+from .dockframe import DockFrame
 from .dockpaned import DockPaned
 from .dockgroup import DockGroup
 from .dockitem import DockItem

--- a/etkdocking/dockstore.py
+++ b/etkdocking/dockstore.py
@@ -54,7 +54,7 @@ def serialize(layout):
     tree = Element('layout')
     list(map(_ser, layout.frames, [tree] * len(layout.frames)))
 
-    return tostring(tree, encoding="utf-8")
+    return tostring(tree, encoding='unicode')
 
 
 widget_factory = {}

--- a/etkdocking/dockstore.py
+++ b/etkdocking/dockstore.py
@@ -119,7 +119,7 @@ def parent_attributes(widget):
     d = {}
 
     if isinstance(container, DockPaned):
-        paned_item = [i for i in container._items if i.get_child() is widget][0]
+        paned_item = [i for i in container._items if i.child is widget][0]
         if paned_item.weight:
             d['weight'] = str(int(paned_item.weight * 100))
 

--- a/etkdocking/hslcolor.py
+++ b/etkdocking/hslcolor.py
@@ -29,6 +29,9 @@ from gi.repository import Gdk, GObject
 
 
 class HslColor(GObject.GObject):
+    """
+
+    """
     __gtype_name__ = 'EtkHslColor'
     __gproperties__ = {'h': (float, 'h', 'h', 0.0, 1.0, 0.0, GObject.ParamFlags.READWRITE),
                        's': (float, 's', 's', 0.0, 1.0, 0.0, GObject.ParamFlags.READWRITE),
@@ -54,6 +57,15 @@ class HslColor(GObject.GObject):
     # GObject
     ############################################################################
     def do_get_property(self, pspec):
+        """Gets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): A property of the CompactButton.
+
+        Returns:
+            The parameter value.
+
+        """
         if pspec.name == 'h':
             return self.get_h()
         elif pspec.name == 's':
@@ -68,6 +80,13 @@ class HslColor(GObject.GObject):
             return self.get_blue_float()
 
     def do_set_property(self, pspec, value):
+        """Sets the property value.
+
+        Args:
+            pspec (GObject.ParamSpec): The property of the CompactButton to set.
+            value: the value to set.
+
+        """
         if pspec.name == 'h':
             self.set_h(value)
         elif pspec.name == 's':
@@ -76,9 +95,21 @@ class HslColor(GObject.GObject):
             self.set_l(value)
 
     def get_h(self):
+        """Gets the color's hue.
+
+        Returns:
+            float: The hue, between 0 and 1.
+
+        """
         return self._h
 
     def set_h(self, value):
+        """Sets the color's hue.
+
+        Args:
+            value (float): The hue value to set, between 0 and 1.
+
+        """
         if value < 0:
             self._h = 0.0
         elif value > 1:
@@ -88,9 +119,21 @@ class HslColor(GObject.GObject):
             self._update_rgb()
 
     def get_s(self):
+        """Gets the color's saturation.
+
+        Returns:
+            float: The saturation, between 0 and 1.
+
+        """
         return self._s
 
     def set_s(self, value):
+        """Sets the color's saturation.
+
+        Args:
+            value (float): The saturation value to set, between 0 and 1.
+
+        """
         if value < 0:
             self._s = 0.0
         elif value > 1:
@@ -100,9 +143,21 @@ class HslColor(GObject.GObject):
             self._update_rgb()
 
     def get_l(self):
+        """Gets the color's lightness.
+
+        Returns:
+            float: The lightness, between 0 and 1.
+
+        """
         return self._l
 
     def set_l(self, value):
+        """Sets the color's lightness.
+
+        Args:
+            value (float): The lightness, between 0 and 1.
+
+        """
         if value < 0:
             self._l = 0.0
         elif value > 1:
@@ -112,27 +167,71 @@ class HslColor(GObject.GObject):
             self._update_rgb()
 
     def get_red_float(self):
+        """Gets the color's red component.
+
+        Returns:
+            float: The red value, between 0 and 1.
+
+        """
         return self._red_float
 
     def get_green_float(self):
+        """Gets the color's green component.
+
+        Returns:
+            float: The green value, between 0 and 1.
+
+        """
         return self._green_float
 
     def get_blue_float(self):
+        """Gets the color's blue component.
+
+        Returns:
+            float: The blue value, between 0 and 1.
+
+        """
         return self._blue_float
 
     def get_rgb_float(self):
+        """Gets the RGB color value as float.
+
+        Returns:
+            tuple of float: red, green, blue (between 0 and 1).
+
+        """
         return (self._red_float, self._green_float, self._blue_float)
 
     def get_rgb(self):
+        """Gets the RGB color value as 16-bit color (0 - 65535).
+
+        Returns:
+            tuple of int: red, green, blue.
+
+        """
         return (int(self._red_float * 65535), int(self._green_float * 65535), int(self._blue_float * 65535))
 
     ############################################################################
     # HslColor
     ############################################################################
     def to_gdk_color(self):
+        """Converts the color to a Gdk.Color.
+
+        TODO: Deprecated, need to use Gdk.RGBA
+
+        Returns:
+            Gdk.Color: The Gdk color object.
+
+        """
         return Gdk.Color(*self.get_rgb_float())
 
     def _update_hsl(self, color):
+        """Update the HSL representation of the color.
+
+        Args:
+            color: The RGB color.
+
+        """
         r = color.red / float(65535)
         g = color.green / float(65535)
         b = color.blue / float(65535)
@@ -179,6 +278,9 @@ class HslColor(GObject.GObject):
         self._h = self._h / 6.0
 
     def _update_rgb(self):
+        """Update RGB representation of the color.
+
+        """
         if self._h > 1: self._h = 1
         if self._h < 0: self._h = 0
         if self._s > 1: self._s = 1

--- a/etkdocking/hslcolor.py
+++ b/etkdocking/hslcolor.py
@@ -30,12 +30,19 @@ from gi.repository import Gdk, GObject
 
 class HslColor(GObject.GObject):
     __gtype_name__ = 'EtkHslColor'
-    __gproperties__ = {'h': (float, 'h', 'h', 0.0, 1.0, 0.0, GObject.PARAM_READWRITE),
-                       's': (float, 's', 's', 0.0, 1.0, 0.0, GObject.PARAM_READWRITE),
-                       'l': (float, 'l', 'l', 0.0, 1.0, 0.0, GObject.PARAM_READWRITE),
-                       'red-float': (float, 'red-float', 'red-float', 0.0, 1.0, 0.0, GObject.PARAM_READABLE),
-                       'green-float': (float, 'green-float', 'green-float', 0.0, 1.0, 0.0, GObject.PARAM_READABLE),
-                       'blue-float': (float, 'blue-float', 'blue-float', 0.0, 1.0, 0.0, GObject.PARAM_READABLE)}
+    __gproperties__ = {'h': (float, 'h', 'h', 0.0, 1.0, 0.0, GObject.ParamFlags.READWRITE),
+                       's': (float, 's', 's', 0.0, 1.0, 0.0, GObject.ParamFlags.READWRITE),
+                       'l': (float, 'l', 'l', 0.0, 1.0, 0.0, GObject.ParamFlags.READWRITE),
+                       'red-float': (
+                           float, 'red-float', 'red-float', 0.0, 1.0, 0.0, GObject.ParamFlags.READABLE
+                       ),
+                       'green-float': (
+                           float, 'green-float', 'green-float', 0.0, 1.0, 0.0, GObject.ParamFlags.READABLE
+                       ),
+                       'blue-float': (
+                           float, 'blue-float', 'blue-float', 0.0, 1.0, 0.0, GObject.ParamFlags.READABLE
+                       )
+                       }
 
     def __init__(self, color):
         GObject.GObject.__init__(self)

--- a/etkdocking/hslcolor.py
+++ b/etkdocking/hslcolor.py
@@ -22,8 +22,10 @@
 from __future__ import division
 
 from builtins import range
-from gi.repository import GObject
-import Gtk.gdk as gdk
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, GObject
 
 
 class HslColor(GObject.GObject):

--- a/etkdocking/hslcolor.py
+++ b/etkdocking/hslcolor.py
@@ -22,21 +22,21 @@
 from __future__ import division
 
 from builtins import range
-import gobject
-import gtk.gdk as gdk
+from gi.repository import GObject
+import Gtk.gdk as gdk
 
 
-class HslColor(gobject.GObject):
+class HslColor(GObject.GObject):
     __gtype_name__ = 'EtkHslColor'
-    __gproperties__ = {'h': (float, 'h', 'h', 0.0, 1.0, 0.0, gobject.PARAM_READWRITE),
-                       's': (float, 's', 's', 0.0, 1.0, 0.0, gobject.PARAM_READWRITE),
-                       'l': (float, 'l', 'l', 0.0, 1.0, 0.0, gobject.PARAM_READWRITE),
-                       'red-float': (float, 'red-float', 'red-float', 0.0, 1.0, 0.0, gobject.PARAM_READABLE),
-                       'green-float': (float, 'green-float', 'green-float', 0.0, 1.0, 0.0, gobject.PARAM_READABLE),
-                       'blue-float': (float, 'blue-float', 'blue-float', 0.0, 1.0, 0.0, gobject.PARAM_READABLE)}
+    __gproperties__ = {'h': (float, 'h', 'h', 0.0, 1.0, 0.0, GObject.PARAM_READWRITE),
+                       's': (float, 's', 's', 0.0, 1.0, 0.0, GObject.PARAM_READWRITE),
+                       'l': (float, 'l', 'l', 0.0, 1.0, 0.0, GObject.PARAM_READWRITE),
+                       'red-float': (float, 'red-float', 'red-float', 0.0, 1.0, 0.0, GObject.PARAM_READABLE),
+                       'green-float': (float, 'green-float', 'green-float', 0.0, 1.0, 0.0, GObject.PARAM_READABLE),
+                       'blue-float': (float, 'blue-float', 'blue-float', 0.0, 1.0, 0.0, GObject.PARAM_READABLE)}
 
     def __init__(self, color):
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         self._update_hsl(color)
         self._update_rgb()
@@ -121,7 +121,7 @@ class HslColor(gobject.GObject):
     # HslColor
     ############################################################################
     def to_gdk_color(self):
-        return gdk.Color(*self.get_rgb_float())
+        return Gdk.Color(*self.get_rgb_float())
 
     def _update_hsl(self, color):
         r = color.red / float(65535)

--- a/etkdocking/util.py
+++ b/etkdocking/util.py
@@ -19,13 +19,13 @@
 # along with etk.docking. If not, see <http://www.gnu.org/licenses/>.
 
 
-import gtk
+from gi.repository import Gtk
 
 
 def rect_contains(rect, x, y):
     '''
     The rect_contains function checks if a point, defined by x and y falls
-    within the gdk.Rectangle defined by rect.
+    within the  defined by rect.
 
     Note: Unlike rect_overlaps defined below, this function ignores a 1 pixel border.
     '''
@@ -38,7 +38,7 @@ def rect_contains(rect, x, y):
 def rect_overlaps(rect, x, y):
     '''
     The rect_overlaps function checks if a point, defined by x and y overlaps
-    the gdk.Rectangle defined by rect.
+    the  defined by rect.
 
     Note: Unlike rect_contains defined above, this function does not ignore a 1 pixel border.
     '''
@@ -50,24 +50,24 @@ def rect_overlaps(rect, x, y):
 
 # TODO: Should change/add on this 'cause it does not work well with IconFactories for example.
 def load_icon(icon_name, size):
-    icontheme = gtk.icon_theme_get_default()
+    icontheme = Gtk.IconTheme.get_default()
 
     if not icontheme.has_icon(icon_name):
         icon_name = 'gtk-missing-image'
 
-    return icontheme.load_icon(icon_name, size, gtk.ICON_LOOKUP_USE_BUILTIN)
+    return icontheme.load_icon(icon_name, size, Gtk.IconLookupFlags.USE_BUILTIN)
 
 
 def load_icon_image(icon_name, size):
-    icontheme = gtk.icon_theme_get_default()
+    icontheme = Gtk.IconTheme.get_default()
 
     if not icontheme.has_icon(icon_name):
         icon_name = 'gtk-missing-image'
 
-    return gtk.image_new_from_icon_name(icon_name, size)
+    return Gtk.Image.new_from_icon_name(icon_name, size)
 
 
-def flatten(w, child_getter=gtk.Container.get_children):
+def flatten(w, child_getter=Gtk.Container.get_children):
     """
     Generator function that returns all items in a hierarchy.
     Default `child_getter` returns children in a GTK+ widget hierarchy.

--- a/etkdocking/util.py
+++ b/etkdocking/util.py
@@ -26,12 +26,21 @@ from gi.repository import Gtk
 
 
 def rect_contains(rect, x, y):
-    '''
-    The rect_contains function checks if a point, defined by x and y falls
-    within the  defined by rect.
+    """Checks if a point, defined by x and y, falls within the rectangle.
 
-    Note: Unlike rect_overlaps defined below, this function ignores a 1 pixel border.
-    '''
+    Note: Unlike rect_overlaps defined below, this function ignores a 1 pixel
+    border. This function is used by the DockGroup to determine if an event
+    occurs within a DockGroupTab.
+
+    Args:
+        rect: An area defined by x, y, width, and height.
+        x (int): The x position of the point.
+        y (int): The y position of the point.
+
+    Returns:
+        bool: True if the point is in the rectangle.
+
+    """
     if x > rect.x and x < rect.x + rect.width and y > rect.y and y < rect.y + rect.height:
         return True
     else:
@@ -39,20 +48,42 @@ def rect_contains(rect, x, y):
 
 
 def rect_overlaps(rect, x, y):
-    '''
-    The rect_overlaps function checks if a point, defined by x and y overlaps
-    the  defined by rect.
+    """Checks if a point, defined by x and y, overlaps the rectangle.
 
-    Note: Unlike rect_contains defined above, this function does not ignore a 1 pixel border.
-    '''
+    Note: Unlike rect_contains defined above, this function does not ignore a 1
+    pixel border. This function is used by DockPaned to determine if an event
+    occurs overlapping a DockPanedHandle.
+
+    Args:
+        rect: An area defined by x, y, width, and height.
+        x (int): The x position of the point.
+        y (int): The y position of the point.
+
+    Returns:
+        bool: True if the point is in the rectangle.
+
+    """
     if x >= rect.x and x <= rect.x + rect.width and y >= rect.y and y <= rect.y + rect.height:
         return True
     else:
         return False
 
 
-# TODO: Should change/add on this 'cause it does not work well with IconFactories for example.
 def load_icon(icon_name, size):
+    """Looks up an icon, scales it and renders it to a pixbuf.
+
+    # TODO: Should change/add on to this. It does not work well with
+    # IconFactories for example.
+
+    Args:
+        icon_name (string): The name of the icon to lookup.
+        size (int): The desired icon size.
+
+    Returns:
+        Gdk.Pixbuf.Pixbuf: The rendered icon as a pixbuf.
+
+    """
+
     icontheme = Gtk.IconTheme.get_default()
 
     if not icontheme.has_icon(icon_name):
@@ -62,6 +93,16 @@ def load_icon(icon_name, size):
 
 
 def load_icon_image(icon_name, size):
+    """Creates a Gtk.Image displaying an icon from the current icon theme.
+
+    Args:
+        icon_name (string): An icon name for the new icon.
+        size (int): A stock icon size (Gtk.IconSize)
+
+    Returns:
+        Gtk.Widget: The created Gtk.Image icon.
+
+    """
     icontheme = Gtk.IconTheme.get_default()
 
     if not icontheme.has_icon(icon_name):
@@ -71,9 +112,17 @@ def load_icon_image(icon_name, size):
 
 
 def flatten(w, child_getter=Gtk.Container.get_children):
-    """
-    Generator function that returns all items in a hierarchy.
+    """Generator function that returns all items in a hierarchy.
+
     Default `child_getter` returns children in a GTK+ widget hierarchy.
+
+    Args:
+        w: The root node of the hierarchy, for Gtk+ often a Window.
+        child_getter: Function call that returns a list of children.
+
+    Yields:
+        object: Item in a hierarchy.
+
     """
     yield w
     try:

--- a/etkdocking/util.py
+++ b/etkdocking/util.py
@@ -19,6 +19,9 @@
 # along with etk.docking. If not, see <http://www.gnu.org/licenses/>.
 
 
+import gi
+
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 

--- a/tests/test_dockgroup.py
+++ b/tests/test_dockgroup.py
@@ -348,15 +348,15 @@ class TestDockGroup(unittest.TestCase):
 
         dockitem1 = DockItem()
         dockgroup.add(dockitem1)
-        self.assertEquals([dockitem1], events)
-        self.assertEquals([True], item_in)
-        self.assertEquals([True], item_in_after)
+        self.assertEqual([dockitem1], events)
+        self.assertEqual([True], item_in)
+        self.assertEqual([True], item_in_after)
 
         dockitem2 = DockItem()
         dockgroup.insert_item(dockitem2)
-        self.assertEquals([dockitem1], events)
-        self.assertEquals([True], item_in)
-        self.assertEquals([True], item_in_after)
+        self.assertEqual([dockitem1], events)
+        self.assertEqual([True], item_in)
+        self.assertEqual([True], item_in_after)
 
     def test_drag_begin(self):
         dockitem1 = DockItem()
@@ -371,7 +371,7 @@ class TestDockGroup(unittest.TestCase):
         window.add(dockgroup)
         window.set_size_request(200, 200)
 
-        self.assertEquals(dockitem3, dockgroup._current_tab.item)
+        self.assertEqual(dockitem3, dockgroup._current_tab.item)
 
     def test_item_closed_event_is_emited_on_close(self):
         dockitem = DockItem()

--- a/tests/test_dockgroup.py
+++ b/tests/test_dockgroup.py
@@ -209,11 +209,11 @@ class TestDockGroup(unittest.TestCase):
 
     def test_get_n_items(self):
         dockgroup = DockGroup()
-        self.assertTrue(dockgroup.get_n_items() == len(dockgroup) == 0)
+        self.assertTrue(dockgroup.get_num_items() == len(dockgroup) == 0)
 
         dockitem = DockItem()
         dockgroup.add(dockitem)
-        self.assertTrue(dockgroup.get_n_items() == len(dockgroup) == 1)
+        self.assertTrue(dockgroup.get_num_items() == len(dockgroup) == 1)
 
         dockitem.destroy()
         dockgroup.destroy()

--- a/tests/test_dockgroup.py
+++ b/tests/test_dockgroup.py
@@ -21,10 +21,6 @@
 
 import unittest
 
-import gi
-
-gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk
 from etkdocking import DockItem, DockGroup
 
 

--- a/tests/test_dockgroup.py
+++ b/tests/test_dockgroup.py
@@ -21,6 +21,11 @@
 
 import unittest
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 from etkdocking import DockItem, DockGroup
 
 

--- a/tests/test_dockgroup.py
+++ b/tests/test_dockgroup.py
@@ -21,10 +21,10 @@
 
 import unittest
 
-import pygtk
+import gi
 
-pygtk.require('2.0')
-import gtk
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 from etkdocking import DockItem, DockGroup
 
 
@@ -44,7 +44,7 @@ class TestDockGroup(unittest.TestCase):
             item_removed_events.append(child)
 
         dockitem = DockItem()
-        dockitem.add(gtk.Button())
+        dockitem.add(Gtk.Button())
         dockgroup = DockGroup()
         dockgroup.connect('remove', on_remove)
         dockgroup.connect('item-removed', on_item_removed)
@@ -98,14 +98,14 @@ class TestDockGroup(unittest.TestCase):
         dockgroup.destroy()
 
     def test_remove(self):
-        win = gtk.Window()
+        win = Gtk.Window()
         dockitem = DockItem()
         dockgroup = DockGroup()
         dockgroup.add(dockitem)
         win.add(dockgroup)
         win.show_all()
 
-        assert dockitem.flags() & gtk.REALIZED
+        assert dockitem.get_realized()
 
         dockgroup.remove(dockitem)
 
@@ -113,11 +113,11 @@ class TestDockGroup(unittest.TestCase):
 
         win.destroy()
 
-        assert not dockitem.flags() & gtk.REALIZED
-        assert not dockgroup.flags() & gtk.REALIZED
+        assert not dockitem.get_realized()
+        assert not dockgroup.get_realized()
 
     def test_item_destroy(self):
-        win = gtk.Window()
+        win = Gtk.Window()
         dockitem = DockItem()
         dockgroup = DockGroup()
         dockgroup.add(dockitem)
@@ -366,7 +366,7 @@ class TestDockGroup(unittest.TestCase):
         dockgroup.add(dockitem2)
         dockgroup.add(dockitem3)
 
-        window = gtk.Window()
+        window = Gtk.Window()
         window.add(dockgroup)
         window.set_size_request(200, 200)
 

--- a/tests/test_dockitem.py
+++ b/tests/test_dockitem.py
@@ -21,6 +21,11 @@
 
 import unittest
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 from etkdocking import DockItem
 
 

--- a/tests/test_dockitem.py
+++ b/tests/test_dockitem.py
@@ -21,11 +21,6 @@
 
 import unittest
 
-import gi
-
-gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk
-
 from etkdocking import DockItem
 
 

--- a/tests/test_dockitem.py
+++ b/tests/test_dockitem.py
@@ -21,10 +21,10 @@
 
 import unittest
 
-import pygtk
+import gi
 
-pygtk.require('2.0')
-import gtk
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 
 from etkdocking import DockItem
 
@@ -143,22 +143,22 @@ class TestDockItem(unittest.TestCase):
         dockitem.connect('notify::stock', _on_notify)
 
         notify_called = False
-        dockitem.set_stock(gtk.STOCK_ABOUT)
-        self.assertEquals(dockitem.get_stock(), gtk.STOCK_ABOUT,
+        dockitem.set_stock(Gtk.STOCK_ABOUT)
+        self.assertEquals(dockitem.get_stock(), Gtk.STOCK_ABOUT,
                           msg='get_stock method did not return expected value')
         self.assertTrue(notify_called,
                         msg='stock property change notification failed when using set_stock method')
 
         notify_called = False
-        dockitem.set_property('stock', gtk.STOCK_ADD)
-        self.assertEquals(dockitem.get_property('stock'), gtk.STOCK_ADD,
+        dockitem.set_property('stock', Gtk.STOCK_ADD)
+        self.assertEquals(dockitem.get_property('stock'), Gtk.STOCK_ADD,
                           msg='get_property method did not return expected value')
         self.assertTrue(notify_called,
                         msg='stock property change notification failed when using set_property method')
 
         notify_called = False
-        dockitem.props.stock = gtk.STOCK_APPLY
-        self.assertEquals(dockitem.props.stock, gtk.STOCK_APPLY,
+        dockitem.props.stock = Gtk.STOCK_APPLY
+        self.assertEquals(dockitem.props.stock, Gtk.STOCK_APPLY,
                           msg='.props attribute did not return expected value')
         self.assertTrue(notify_called,
                         msg='stock property change notification failed when using .props attribute')
@@ -169,38 +169,38 @@ class TestDockItem(unittest.TestCase):
         # TODO: is there a way to check we actually received the image we expect?
         dockitem = DockItem()
         dockitem.set_icon_name('someicon')
-        self.assertTrue(isinstance(dockitem.get_image(), gtk.Image))
-        self.assertTrue(isinstance(dockitem.props.image, gtk.Image))
-        self.assertTrue(isinstance(dockitem.get_property('image'), gtk.Image))
+        self.assertTrue(isinstance(dockitem.get_image(), Gtk.Image))
+        self.assertTrue(isinstance(dockitem.props.image, Gtk.Image))
+        self.assertTrue(isinstance(dockitem.get_property('image'), Gtk.Image))
         dockitem.destroy()
 
         dockitem = DockItem()
-        dockitem.set_stock(gtk.STOCK_ABOUT)
-        self.assertTrue(isinstance(dockitem.get_image(), gtk.Image))
-        self.assertTrue(isinstance(dockitem.props.image, gtk.Image))
-        self.assertTrue(isinstance(dockitem.get_property('image'), gtk.Image))
+        dockitem.set_stock(Gtk.STOCK_ABOUT)
+        self.assertTrue(isinstance(dockitem.get_image(), Gtk.Image))
+        self.assertTrue(isinstance(dockitem.props.image, Gtk.Image))
+        self.assertTrue(isinstance(dockitem.get_property('image'), Gtk.Image))
         dockitem.destroy()
 
     ############################################################################
     # Test public api
     ############################################################################
     def test_add(self):
-        button = gtk.Button()
+        button = Gtk.Button()
         dockitem = DockItem()
         dockitem.add(button)
 
-        self.assertTrue(dockitem.child is button)
+        self.assertTrue(dockitem.get_child() is button)
 
         button.destroy()
         dockitem.destroy()
 
     def test_remove(self):
-        button = gtk.Button()
+        button = Gtk.Button()
         dockitem = DockItem()
         dockitem.add(button)
         dockitem.remove(button)
 
-        self.assertTrue(dockitem.child is None)
+        self.assertTrue(dockitem.get_child() is None)
 
         button.destroy()
         dockitem.destroy()
@@ -209,18 +209,18 @@ class TestDockItem(unittest.TestCase):
     # Test appearance
     ############################################################################
 #    def test_appearance(self):
-#        frame = gtk.Frame()
-#        frame.set_shadow_type(gtk.SHADOW_NONE)
+#        frame = Gtk.Frame()
+#        frame.set_shadow_type(Gtk.ShadowType.NONE)
 #        frame.set_size_request(25, 25)
 #        di = DockItem('gtk-missing-image', 'test')
 #        di.add(frame)
 #        dg = DockGroup()
 #        dg.add(di)
-#        window = gtk.Window()
+#        window = Gtk.Window()
 #        window.add(dg)
 #        window.show_all()
 #
 #        snapshot = dg.get_snapshot(None)
-#        pixbuf = gdk.Pixbuf(gdk.COLORSPACE_RGB, True, 8, *snapshot.get_size())
+#        pixbuf = GdkPixbuf.Pixbuf(GdkPixbuf.Colorspace.RGB, True, 8, *snapshot.get_size())
 #        pixbuf.get_from_drawable(snapshot, window.get_colormap(), 0, 0, 0, 0, *snapshot.get_size())
 #        pixbuf.save(os.path.join(os.path.dirname(__file__), 'test_dockitem.test_appearance.png'), 'png', {})

--- a/tests/test_dockitem.py
+++ b/tests/test_dockitem.py
@@ -45,21 +45,21 @@ class TestDockItem(unittest.TestCase):
 
         notify_called = False
         dockitem.set_title('sometitle')
-        self.assertEquals(dockitem.get_title(), 'sometitle',
+        self.assertEqual(dockitem.get_title(), 'sometitle',
                           msg='get_title method did not return expected value')
         self.assertTrue(notify_called,
                         msg='title property change notification failed when using set_title method')
 
         notify_called = False
         dockitem.set_property('title', 'anothertitle')
-        self.assertEquals(dockitem.get_property('title'), 'anothertitle',
+        self.assertEqual(dockitem.get_property('title'), 'anothertitle',
                           msg='get_property method did not return expected value')
         self.assertTrue(notify_called,
                         msg='title property change notification failed when using set_property method')
 
         notify_called = False
         dockitem.props.title = 'hello'
-        self.assertEquals(dockitem.props.title, 'hello',
+        self.assertEqual(dockitem.props.title, 'hello',
                           msg='.props attribute did not return expected value')
         self.assertTrue(notify_called,
                         msg='title property change notification failed when using .props attribute')
@@ -78,21 +78,21 @@ class TestDockItem(unittest.TestCase):
 
         notify_called = False
         dockitem.set_title_tooltip_text('sometext')
-        self.assertEquals(dockitem.get_title_tooltip_text(), 'sometext',
+        self.assertEqual(dockitem.get_title_tooltip_text(), 'sometext',
                           msg='get_title_tooltip_text method did not return expected value')
         self.assertTrue(notify_called,
                         msg='title-tooltip-text property change notification failed when using set_title_tooltip_text method')
 
         notify_called = False
         dockitem.set_property('title-tooltip-text', 'anothertext')
-        self.assertEquals(dockitem.get_property('title-tooltip-text'), 'anothertext',
+        self.assertEqual(dockitem.get_property('title-tooltip-text'), 'anothertext',
                           msg='get_property method did not return expected value')
         self.assertTrue(notify_called,
                         msg='title-tooltip-text property change notification failed when using set_title_tooltip_text method')
 
         notify_called = False
         dockitem.props.title_tooltip_text = 'hello'
-        self.assertEquals(dockitem.props.title_tooltip_text, 'hello',
+        self.assertEqual(dockitem.props.title_tooltip_text, 'hello',
                           msg='.props attribute did not return expected value')
         self.assertTrue(notify_called,
                         msg='title-tooltip-text property change notification failed when using .props attribute')
@@ -111,21 +111,21 @@ class TestDockItem(unittest.TestCase):
 
         notify_called = False
         dockitem.set_icon_name('someicon')
-        self.assertEquals(dockitem.get_icon_name(), 'someicon',
+        self.assertEqual(dockitem.get_icon_name(), 'someicon',
                           msg='get_icon_name method did not return expected value')
         self.assertTrue(notify_called,
                         msg='icon-name property change notification failed when using set_icon_name method')
 
         notify_called = False
         dockitem.set_property('icon-name', 'anothericon')
-        self.assertEquals(dockitem.get_property('icon-name'), 'anothericon',
+        self.assertEqual(dockitem.get_property('icon-name'), 'anothericon',
                           msg='get_property method did not return expected value')
         self.assertTrue(notify_called,
                         msg='icon-name property change notification failed when using set_property method')
 
         notify_called = False
         dockitem.props.icon_name = 'niceicon'
-        self.assertEquals(dockitem.props.icon_name, 'niceicon',
+        self.assertEqual(dockitem.props.icon_name, 'niceicon',
                           msg='.props attribute did not return expected value')
         self.assertTrue(notify_called,
                         msg='icon-name property change notification failed when using .props attribute')
@@ -144,21 +144,21 @@ class TestDockItem(unittest.TestCase):
 
         notify_called = False
         dockitem.set_stock(Gtk.STOCK_ABOUT)
-        self.assertEquals(dockitem.get_stock(), Gtk.STOCK_ABOUT,
+        self.assertEqual(dockitem.get_stock(), Gtk.STOCK_ABOUT,
                           msg='get_stock method did not return expected value')
         self.assertTrue(notify_called,
                         msg='stock property change notification failed when using set_stock method')
 
         notify_called = False
         dockitem.set_property('stock', Gtk.STOCK_ADD)
-        self.assertEquals(dockitem.get_property('stock'), Gtk.STOCK_ADD,
+        self.assertEqual(dockitem.get_property('stock'), Gtk.STOCK_ADD,
                           msg='get_property method did not return expected value')
         self.assertTrue(notify_called,
                         msg='stock property change notification failed when using set_property method')
 
         notify_called = False
         dockitem.props.stock = Gtk.STOCK_APPLY
-        self.assertEquals(dockitem.props.stock, Gtk.STOCK_APPLY,
+        self.assertEqual(dockitem.props.stock, Gtk.STOCK_APPLY,
                           msg='.props attribute did not return expected value')
         self.assertTrue(notify_called,
                         msg='stock property change notification failed when using .props attribute')

--- a/tests/test_docklayout.py
+++ b/tests/test_docklayout.py
@@ -139,7 +139,7 @@ class TestDockLayout(unittest.TestCase):
 
 class StubContext(object):
     def __init__(self, source_widget, items):
-        self.targets = [ DRAG_TARGET_ITEM_LIST[0] ]
+        self.targets = [DRAG_TARGET_ITEM_LIST.target]
         self.source_widget = source_widget
         # Set up dragcontext (nornally done in motion_notify event)
         if items:

--- a/tests/test_docklayout.py
+++ b/tests/test_docklayout.py
@@ -36,7 +36,7 @@ from etkdocking.dnd import DockDragContext
 class TestDockLayout(unittest.TestCase):
 
     def test_construction(self):
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         group = DockGroup()
@@ -62,7 +62,7 @@ class TestDockLayout(unittest.TestCase):
         assert frame not in layout.frames
 
     def test_construction_after_setting_layout(self):
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         group = DockGroup()
@@ -91,7 +91,7 @@ class TestDockLayout(unittest.TestCase):
         assert frame in layout.frames
 
     def test_get_widgets(self):
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         group = DockGroup()
@@ -179,7 +179,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         del DockFrame.drag_get_data
 
     def test_drag_drop_on_group(self):
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         group = DockGroup()
@@ -213,7 +213,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         layout.on_widget_drag_drop(group, context, x, y, 0)
 
     def test_drag_drop_on_paned(self):
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         groups = (DockGroup(), DockGroup())
@@ -240,7 +240,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         assert layout._drag_data.drop_widget is paned, '%s != %s' % (layout._drag_data.drop_widget, paned)
 
     def test_remove_paned_with_one_child(self):
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         groups = (DockGroup(), DockGroup())
@@ -266,7 +266,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         assert groups[1].get_parent() is frame
 
     def test_remove_nested_paned_with_one_child(self):
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paneds = (DockPaned(), DockPaned())
         groups = (DockGroup(), DockGroup())
@@ -295,7 +295,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         assert groups[1].get_parent() is paneds[0], (paneds, groups[1].get_parent())
 
     def test_remove_empty_groups_recursively(self):
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paneds = (DockPaned(), DockPaned(), DockPaned())
         group = DockGroup()
@@ -326,7 +326,7 @@ class PlacementTest(unittest.TestCase):
 
     def setUp(self):
         self.layout = DockLayout()
-        self.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        self.window = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         self.frame = DockFrame()
         self.group = DockGroup()
 

--- a/tests/test_docklayout.py
+++ b/tests/test_docklayout.py
@@ -24,9 +24,9 @@ from builtins import object
 from builtins import map
 import unittest
 
-import pygtk
-pygtk.require('2.0')
-import gtk
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 from etkdocking import DockLayout, DockFrame, DockPaned, DockGroup, DockItem
 from etkdocking.dockgroup import DockGroup, DRAG_TARGET_ITEM_LIST
 from etkdocking.dnd import DockDragContext
@@ -34,7 +34,7 @@ from etkdocking.dnd import DockDragContext
 class TestDockLayout(unittest.TestCase):
 
     def test_construction(self):
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         group = DockGroup()
@@ -60,7 +60,7 @@ class TestDockLayout(unittest.TestCase):
         assert frame not in layout.frames
 
     def test_construction_after_setting_layout(self):
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         group = DockGroup()
@@ -89,12 +89,12 @@ class TestDockLayout(unittest.TestCase):
         assert frame in layout.frames
 
     def test_get_widgets(self):
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         group = DockGroup()
         item = DockItem()
-        label = gtk.Label()
+        label = Gtk.Label()
 
         layout = DockLayout()
 
@@ -177,7 +177,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         del DockFrame.drag_get_data
 
     def test_drag_drop_on_group(self):
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         group = DockGroup()
@@ -195,8 +195,8 @@ class TestDockLayoutDnD(unittest.TestCase):
         win.set_default_size(200, 200)
         win.show_all()
 
-        while gtk.events_pending():
-            gtk.main_iteration()
+        while Gtk.events_pending():
+            Gtk.main_iteration()
 
 
         context = StubContext(group, [group.items[0]])
@@ -211,7 +211,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         layout.on_widget_drag_drop(group, context, x, y, 0)
 
     def test_drag_drop_on_paned(self):
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         groups = (DockGroup(), DockGroup())
@@ -238,7 +238,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         assert layout._drag_data.drop_widget is paned, '%s != %s' % (layout._drag_data.drop_widget, paned)
 
     def test_remove_paned_with_one_child(self):
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paned = DockPaned()
         groups = (DockGroup(), DockGroup())
@@ -264,7 +264,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         assert groups[1].get_parent() is frame
 
     def test_remove_nested_paned_with_one_child(self):
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paneds = (DockPaned(), DockPaned())
         groups = (DockGroup(), DockGroup())
@@ -293,7 +293,7 @@ class TestDockLayoutDnD(unittest.TestCase):
         assert groups[1].get_parent() is paneds[0], (paneds, groups[1].get_parent())
 
     def test_remove_empty_groups_recursively(self):
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         frame = DockFrame()
         paneds = (DockPaned(), DockPaned(), DockPaned())
         group = DockGroup()
@@ -324,7 +324,7 @@ class PlacementTest(unittest.TestCase):
 
     def setUp(self):
         self.layout = DockLayout()
-        self.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        self.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         self.frame = DockFrame()
         self.group = DockGroup()
 

--- a/tests/test_docklayout.py
+++ b/tests/test_docklayout.py
@@ -53,8 +53,8 @@ class TestDockLayout(unittest.TestCase):
 
         assert frame in layout.frames
         print(layout._signal_handlers)
-        self.assertEquals(4, len(layout._signal_handlers))
-        self.assertEquals(9, len(layout._signal_handlers[frame]))
+        self.assertEqual(4, len(layout._signal_handlers))
+        self.assertEqual(9, len(layout._signal_handlers[frame]))
 
         layout.remove(frame)
 
@@ -78,12 +78,12 @@ class TestDockLayout(unittest.TestCase):
         group.add(item)
 
         assert frame in layout.frames
-        self.assertEquals(4, len(layout._signal_handlers))
-        self.assertEquals(9, len(layout._signal_handlers[frame]))
+        self.assertEqual(4, len(layout._signal_handlers))
+        self.assertEqual(9, len(layout._signal_handlers[frame]))
 
         paned.remove(group)
 
-        self.assertEquals(2, len(layout._signal_handlers), layout._signal_handlers)
+        self.assertEqual(2, len(layout._signal_handlers), layout._signal_handlers)
         assert frame in list(layout._signal_handlers.keys()), layout._signal_handlers
         assert paned in list(layout._signal_handlers.keys()), layout._signal_handlers
         assert group not in list(layout._signal_handlers.keys()), layout._signal_handlers

--- a/tests/test_docklayout.py
+++ b/tests/test_docklayout.py
@@ -24,6 +24,11 @@ from builtins import object
 from builtins import map
 import unittest
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 from etkdocking import DockLayout, DockFrame, DockPaned, DockGroup, DockItem
 from etkdocking.dockgroup import DockGroup, DRAG_TARGET_ITEM_LIST
 from etkdocking.dnd import DockDragContext

--- a/tests/test_docklayout.py
+++ b/tests/test_docklayout.py
@@ -24,9 +24,6 @@ from builtins import object
 from builtins import map
 import unittest
 
-import gi
-gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk
 from etkdocking import DockLayout, DockFrame, DockPaned, DockGroup, DockItem
 from etkdocking.dockgroup import DockGroup, DRAG_TARGET_ITEM_LIST
 from etkdocking.dnd import DockDragContext

--- a/tests/test_dockpaned.py
+++ b/tests/test_dockpaned.py
@@ -45,21 +45,21 @@ class TestDockPaned(unittest.TestCase):
 
         notify_called = False
         dockpaned.set_handle_size(1)
-        self.assertEquals(dockpaned.get_handle_size(), 1,
+        self.assertEqual(dockpaned.get_handle_size(), 1,
                           msg='get_handle_size method did not return expected value')
         self.assertTrue(notify_called,
                         msg='handle-size property change notification failed when using set_handle_size method')
 
         notify_called = False
         dockpaned.set_property('handle-size', 2)
-        self.assertEquals(dockpaned.get_property('handle-size'), 2,
+        self.assertEqual(dockpaned.get_property('handle-size'), 2,
                           msg='get_property method did not return expected value')
         self.assertTrue(notify_called,
                         msg='handle-size property change notification failed when using set_property method')
 
         notify_called = False
         dockpaned.props.handle_size = 3
-        self.assertEquals(dockpaned.props.handle_size, 3,
+        self.assertEqual(dockpaned.props.handle_size, 3,
                           msg='.props attribute did not return expected value')
         self.assertTrue(notify_called,
                         msg='handle-size property change notification failed when using .props attribute')
@@ -78,21 +78,21 @@ class TestDockPaned(unittest.TestCase):
 
         notify_called = False
         dockpaned.set_orientation(Gtk.Orientation.VERTICAL)
-        self.assertEquals(dockpaned.get_orientation(), Gtk.Orientation.VERTICAL,
+        self.assertEqual(dockpaned.get_orientation(), Gtk.Orientation.VERTICAL,
                           msg='get_orientation method did not return expected value')
         self.assertTrue(notify_called,
                         msg='orientation property change notification failed when using set_orientation method')
 
         notify_called = False
         dockpaned.set_property('orientation', Gtk.Orientation.HORIZONTAL)
-        self.assertEquals(dockpaned.get_property('orientation'), Gtk.Orientation.HORIZONTAL,
+        self.assertEqual(dockpaned.get_property('orientation'), Gtk.Orientation.HORIZONTAL,
                           msg='get_property method did not return expected value')
         self.assertTrue(notify_called,
                         msg='orientation property change notification failed when using set_property method')
 
         notify_called = False
         dockpaned.props.orientation = Gtk.Orientation.VERTICAL
-        self.assertEquals(dockpaned.props.orientation, Gtk.Orientation.VERTICAL,
+        self.assertEqual(dockpaned.props.orientation, Gtk.Orientation.VERTICAL,
                           msg='.props attribute did not return expected value')
         self.assertTrue(notify_called,
                         msg='orientation property change notification failed when using .props attribute')
@@ -232,14 +232,14 @@ class TestDockPaned(unittest.TestCase):
         dockpaned.insert_item(dockgroup1)
         dockpaned._items[0].min_size = 20
 
-        self.assertEquals(1, len(dockpaned._items))
-        self.assertEquals(1.0, dockpaned._items[0].weight)
-        self.assertEquals(None, dockpaned._items[0].weight_request)
+        self.assertEqual(1, len(dockpaned._items))
+        self.assertEqual(1.0, dockpaned._items[0].weight)
+        self.assertEqual(None, dockpaned._items[0].weight_request)
 
         dockpaned._redistribute_weight(100)
 
-        self.assertEquals(1.0, dockpaned._items[0].weight)
-        self.assertEquals(None, dockpaned._items[0].weight_request)
+        self.assertEqual(1.0, dockpaned._items[0].weight)
+        self.assertEqual(None, dockpaned._items[0].weight_request)
 
         dockpaned.insert_item(dockgroup2, weight=0.5)
         dockpaned._items[1].min_size = 20
@@ -248,8 +248,8 @@ class TestDockPaned(unittest.TestCase):
 
         dockpaned._redistribute_weight(100)
 
-        self.assertAlmostEquals(0.5, dockpaned._items[0].weight, 4)
-        self.assertAlmostEquals(0.5, dockpaned._items[1].weight, 4)
+        self.assertAlmostEqual(0.5, dockpaned._items[0].weight, 4)
+        self.assertAlmostEqual(0.5, dockpaned._items[1].weight, 4)
 
     def test_redistribute_weight_resize(self):
         dockpaned = DockPaned()
@@ -259,14 +259,14 @@ class TestDockPaned(unittest.TestCase):
         dockpaned.insert_item(dockgroup1, weight=0.5)
         dockpaned._items[0].min_size = 20
 
-        self.assertEquals(1, len(dockpaned._items))
-        self.assertEquals(None, dockpaned._items[0].weight)
-        self.assertEquals(0.5, dockpaned._items[0].weight_request)
+        self.assertEqual(1, len(dockpaned._items))
+        self.assertEqual(None, dockpaned._items[0].weight)
+        self.assertEqual(0.5, dockpaned._items[0].weight_request)
 
         dockpaned._redistribute_weight(100)
 
-        self.assertEquals(1.0, dockpaned._items[0].weight)
-        self.assertEquals(None, dockpaned._items[0].weight_request)
+        self.assertEqual(1.0, dockpaned._items[0].weight)
+        self.assertEqual(None, dockpaned._items[0].weight_request)
 
         dockpaned.insert_item(dockgroup2, weight=0.5)
         dockpaned._items[1].min_size = 20
@@ -275,8 +275,8 @@ class TestDockPaned(unittest.TestCase):
 
         dockpaned._redistribute_weight(100)
 
-        self.assertAlmostEquals(0.5, dockpaned._items[0].weight, 4)
-        self.assertAlmostEquals(0.5, dockpaned._items[1].weight, 4)
+        self.assertAlmostEqual(0.5, dockpaned._items[0].weight, 4)
+        self.assertAlmostEqual(0.5, dockpaned._items[1].weight, 4)
 
     ############################################################################
     # Test public api

--- a/tests/test_dockpaned.py
+++ b/tests/test_dockpaned.py
@@ -21,11 +21,11 @@
 
 import unittest
 
-import pygtk
+import gi
 
-pygtk.require('2.0')
-import gtk
-import gtk.gdk as gdk
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+import Gtk.gdk as gdk
 
 from etkdocking import DockPaned, DockGroup
 
@@ -78,22 +78,22 @@ class TestDockPaned(unittest.TestCase):
         dockpaned.connect('notify::orientation', _on_notify)
 
         notify_called = False
-        dockpaned.set_orientation(gtk.ORIENTATION_VERTICAL)
-        self.assertEquals(dockpaned.get_orientation(), gtk.ORIENTATION_VERTICAL,
+        dockpaned.set_orientation(Gtk.Orientation.VERTICAL)
+        self.assertEquals(dockpaned.get_orientation(), Gtk.Orientation.VERTICAL,
                           msg='get_orientation method did not return expected value')
         self.assertTrue(notify_called,
                         msg='orientation property change notification failed when using set_orientation method')
 
         notify_called = False
-        dockpaned.set_property('orientation', gtk.ORIENTATION_HORIZONTAL)
-        self.assertEquals(dockpaned.get_property('orientation'), gtk.ORIENTATION_HORIZONTAL,
+        dockpaned.set_property('orientation', Gtk.Orientation.HORIZONTAL)
+        self.assertEquals(dockpaned.get_property('orientation'), Gtk.Orientation.HORIZONTAL,
                           msg='get_property method did not return expected value')
         self.assertTrue(notify_called,
                         msg='orientation property change notification failed when using set_property method')
 
         notify_called = False
-        dockpaned.props.orientation = gtk.ORIENTATION_VERTICAL
-        self.assertEquals(dockpaned.props.orientation, gtk.ORIENTATION_VERTICAL,
+        dockpaned.props.orientation = Gtk.Orientation.VERTICAL
+        self.assertEquals(dockpaned.props.orientation, Gtk.Orientation.VERTICAL,
                           msg='.props attribute did not return expected value')
         self.assertTrue(notify_called,
                         msg='orientation property change notification failed when using .props attribute')
@@ -452,7 +452,7 @@ class TestDockPaned(unittest.TestCase):
         dockpaned = DockPaned()
         dockpaned.add(dockgroup1)
         dockpaned.add(dockgroup2)
-        window = gtk.Window()
+        window = Gtk.Window()
         window.add(dockpaned)
         window.show_all()
 

--- a/tests/test_dockpaned.py
+++ b/tests/test_dockpaned.py
@@ -455,13 +455,11 @@ class TestDockPaned(unittest.TestCase):
         window.add(dockpaned)
         window.show_all()
 
-        child1 = dockpaned.get_item_at_pos(
-            dockgroup1.get_allocation().x + 1, dockgroup1.get_allocation().y + 1
-        )
+        child1 = dockpaned.get_item_at_pos(dockgroup1.allocation.x + 1,
+                                           dockgroup1.allocation.y + 1)
 
-        child2 = dockpaned.get_item_at_pos(
-            dockgroup2.get_allocation().x + 1, dockgroup2.get_allocation().y + 1
-        )
+        child2 = dockpaned.get_item_at_pos(dockgroup2.allocation.x + 1,
+                                           dockgroup2.allocation.y + 1)
 
         self.assertTrue(child1 is dockgroup1)
         self.assertTrue(child2 is dockgroup2)

--- a/tests/test_dockpaned.py
+++ b/tests/test_dockpaned.py
@@ -425,7 +425,7 @@ class TestDockPaned(unittest.TestCase):
         dockpaned.add(dockgroup1)
         dockpaned.add(dockgroup2)
 
-        self.assertTrue(dockpaned._get_n_handles() == 1)
+        self.assertTrue(dockpaned._get_num_handles() == 1)
 
         dockgroup2.destroy()
         dockgroup1.destroy()

--- a/tests/test_dockpaned.py
+++ b/tests/test_dockpaned.py
@@ -111,11 +111,11 @@ class TestDockPaned(unittest.TestCase):
 
         dockpaned = DockPaned()
         dockgroup = DockGroup()
-        dockgroup.connect('child-notify::weight', _on_child_notify)
+        dockgroup.connect('notify::weight', _on_child_notify)
         dockpaned.add(dockgroup)
 
         child_notify_called = False
-        dockpaned.child_set_property(dockgroup, 'weight', 0.3)
+        dockgroup.props.weight = 0.3
         self.assertTrue(child_notify_called,
                         msg='weight child property change notification failed')
 

--- a/tests/test_dockpaned.py
+++ b/tests/test_dockpaned.py
@@ -455,11 +455,13 @@ class TestDockPaned(unittest.TestCase):
         window.add(dockpaned)
         window.show_all()
 
-        child1 = dockpaned.get_item_at_pos(dockgroup1.allocation.x + 1,
-                                           dockgroup1.allocation.y + 1)
+        child1 = dockpaned.get_item_at_pos(
+            dockgroup1.get_allocation().x + 1, dockgroup1.get_allocation().y + 1
+        )
 
-        child2 = dockpaned.get_item_at_pos(dockgroup2.allocation.x + 1,
-                                           dockgroup2.allocation.y + 1)
+        child2 = dockpaned.get_item_at_pos(
+            dockgroup2.get_allocation().x + 1, dockgroup2.get_allocation().y + 1
+        )
 
         self.assertTrue(child1 is dockgroup1)
         self.assertTrue(child2 is dockgroup2)

--- a/tests/test_dockpaned.py
+++ b/tests/test_dockpaned.py
@@ -21,12 +21,6 @@
 
 import unittest
 
-import gi
-
-gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk
-import Gtk.gdk as gdk
-
 from etkdocking import DockPaned, DockGroup
 
 

--- a/tests/test_dockpaned.py
+++ b/tests/test_dockpaned.py
@@ -21,6 +21,11 @@
 
 import unittest
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 from etkdocking import DockPaned, DockGroup
 
 

--- a/tests/test_dockstore.py
+++ b/tests/test_dockstore.py
@@ -118,8 +118,8 @@ class LoadingTestCase(unittest.TestCase):
 
         assert floating_frames[0].get_toplevel().get_transient_for() is win
 
-        self.assertEquals(0.45, main_frames[0].get_children()[0]._items[0].weight_request)
+        self.assertEqual(0.45, main_frames[0].get_children()[0]._items[0].weight_request)
 
         win.show_all()
 
-        self.assertEquals(0.45, main_frames[0].get_children()[0]._items[0].weight)
+        self.assertEqual(0.45, main_frames[0].get_children()[0]._items[0].weight)

--- a/tests/test_dockstore.py
+++ b/tests/test_dockstore.py
@@ -3,10 +3,6 @@ from builtins import object
 from builtins import next
 import unittest
 
-import gi
-
-gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk
 from etkdocking import DockLayout, DockFrame, DockPaned, DockGroup, DockItem
 from etkdocking.dockstore import serialize, deserialize, get_main_frames, finish
 

--- a/tests/test_dockstore.py
+++ b/tests/test_dockstore.py
@@ -36,12 +36,11 @@ class LoadingTestCase(unittest.TestCase):
 
         s = serialize(layout)
         print(s)
-        assert bytes(b'<layout><dockframe height="1" width="1">'
-                     b'<dockpaned orientation="horizontal">'
-                     b'<dockgroup weight="100">'
-                     b'<dockitem icon_name="icon" title="t" tooltip="xx" />'
-                     b'</dockgroup></dockpaned></dockframe></layout>'
-                     ) == s, s
+        assert '<layout><dockframe height="1" width="1">' \
+               '<dockpaned orientation="horizontal">' \
+               '<dockgroup weight="100">' \
+               '<dockitem icon_name="icon" title="t" tooltip="xx" />' \
+               '</dockgroup></dockpaned></dockframe></layout>' == s, s
 
     def test_deserialize(self):
         xml = '''

--- a/tests/test_dockstore.py
+++ b/tests/test_dockstore.py
@@ -15,13 +15,13 @@ from etkdocking.dockstore import serialize, deserialize, get_main_frames, finish
 class ItemFactory(object):
 
     def __call__(self, label):
-        return Gtk.Button(label)
+        return Gtk.Button.new_with_label(label)
 
 
 class LoadingTestCase(unittest.TestCase):
 
     def test_serialize(self):
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         layout = DockLayout()
         frame = DockFrame()
         win.add(frame)
@@ -71,7 +71,7 @@ class LoadingTestCase(unittest.TestCase):
         button = item.get_child()
         assert isinstance(button, Gtk.Button)
         assert "fillme" == button.get_label(), button.get_label()
-        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
         win.add(frame)
         win.show()
         while Gtk.events_pending():

--- a/tests/test_dockstore.py
+++ b/tests/test_dockstore.py
@@ -3,6 +3,11 @@ from builtins import object
 from builtins import next
 import unittest
 
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 from etkdocking import DockLayout, DockFrame, DockPaned, DockGroup, DockItem
 from etkdocking.dockstore import serialize, deserialize, get_main_frames, finish
 

--- a/tests/test_dockstore.py
+++ b/tests/test_dockstore.py
@@ -3,10 +3,10 @@ from builtins import object
 from builtins import next
 import unittest
 
-import pygtk
+import gi
 
-pygtk.require('2.0')
-import gtk
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 from etkdocking import DockLayout, DockFrame, DockPaned, DockGroup, DockItem
 from etkdocking.dockstore import serialize, deserialize, get_main_frames, finish
 
@@ -14,13 +14,13 @@ from etkdocking.dockstore import serialize, deserialize, get_main_frames, finish
 class ItemFactory(object):
 
     def __call__(self, label):
-        return gtk.Button(label)
+        return Gtk.Button(label)
 
 
 class LoadingTestCase(unittest.TestCase):
 
     def test_serialize(self):
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         layout = DockLayout()
         frame = DockFrame()
         win.add(frame)
@@ -60,22 +60,22 @@ class LoadingTestCase(unittest.TestCase):
         layout = deserialize(xml, ItemFactory())
         assert 1, len(layout.frames)
         frame = next(iter(layout.frames))
-        assert frame.child
-        paned = frame.child
+        assert frame.get_child()
+        paned = frame.get_child()
         assert len(paned)
         group = paned.get_nth_item(0)
         assert isinstance(group, DockGroup), group
         assert len(group)
         item = group.get_nth_item(0)
         assert isinstance(item, DockItem)
-        button = item.child
-        assert isinstance(button, gtk.Button)
+        button = item.get_child()
+        assert isinstance(button, Gtk.Button)
         assert "fillme" == button.get_label(), button.get_label()
-        win = gtk.Window(gtk.WINDOW_TOPLEVEL)
+        win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         win.add(frame)
         win.show()
-        while gtk.events_pending():
-            gtk.main_iteration()
+        while Gtk.events_pending():
+            Gtk.main_iteration()
 
         # assert frame.allocation.width == 200, frame.allocation.width
         # assert frame.allocation.height == 120, frame.allocation.height
@@ -107,7 +107,7 @@ class LoadingTestCase(unittest.TestCase):
         assert len(layout.frames) == 2, layout.frames
         frames = list(get_main_frames(layout))
         assert len(frames) == 1, frames
-        win = gtk.Window()
+        win = Gtk.Window()
         win.add(frames[0])
         finish(layout, frames[0])
 

--- a/tests/test_dockstore.py
+++ b/tests/test_dockstore.py
@@ -118,8 +118,8 @@ class LoadingTestCase(unittest.TestCase):
 
         assert floating_frames[0].get_toplevel().get_transient_for() is win
 
-        self.assertEqual(0.45, main_frames[0].get_children()[0]._items[0].weight_request)
+        self.assertEqual(0.45, main_frames[0].get_child()._items[0].weight_request)
 
         win.show_all()
 
-        self.assertEqual(0.45, main_frames[0].get_children()[0]._items[0].weight)
+        self.assertEqual(0.45, main_frames[0].get_child()._items[0].weight)


### PR DESCRIPTION
TODO:
- [ ] Fix Gdk-CRITICAL warnings "assertion 'GDK_IS_WINDOW (window)' failed", anyone familiar with using gdb to get a Gtk+ stacktrace through PyGObject?
- [ ] Docklayout DnD behavior for propagate_to_parent is getting a "TypeError: cannot unpack non-iterable NoneType object" because the parent is not realized
- [ ] Dockpaned is not properly getting a dockgroup via get_item_at_pos
- [ ] Test using the demo and dockgroupdemo, as well as with Gaphor

Currently passing 64/67 tests. 